### PR TITLE
feat: add ** (exponentiation) operator to parser

### DIFF
--- a/DATASETS.md
+++ b/DATASETS.md
@@ -2,7 +2,7 @@
 
 CoBRA is validated against **72,646 expressions** drawn from **31 dataset files** spanning 6 independent sources. Every expression is parsed, simplified, and spot-checked at runtime. The numbers below are enforced by automated test assertions in [`test/verify/test_dataset_benchmarks.cpp`](test/verify/test_dataset_benchmarks.cpp) and verified on every CI run.
 
-**Overall: 69,472 / 69,572 parsed expressions simplified (99.86%), zero failures.**
+**Overall: 69,482 / 69,582 parsed expressions simplified (99.86%), zero failures.**
 
 ---
 
@@ -27,11 +27,11 @@ CoBRA classifies each input expression into one of four semantic classes, then r
 |---------|:-----------:|:------:|:----------:|:-----------:|:----:|
 | `univariate64.txt` | 1,000 | 1,000 | **1,000** | 0 | **100%** |
 | `multivariate64.txt` | 1,000 | 1,000 | **1,000** | 0 | **100%** |
-| `permutation64.txt` | 13 | 3 | **3** | 0 | **100%** |
+| `permutation64.txt` | 13 | 13 | **13** | 0 | **100%** |
 | `msimba.txt` | 1,000 | 1,000 | **1,000** | 0 | **100%** |
 
 - **univariate64** / **multivariate64**: Polynomial expressions (`x0*x0`, `x0*x1`) that simplify to linear targets. All 2,000 pass full-width verification.
-- **permutation64**: High-degree polynomial expressions. 10 of 13 use `**` (exponentiation), which the parser does not support; the 3 parseable expressions simplify correctly.
+- **permutation64**: High-degree polynomial expressions with `**` (exponentiation). All 13 expressions parse and simplify correctly.
 - **msimba**: Semilinear expressions with bit-extraction patterns. All 1,000 simplified via the bit-partitioned pipeline.
 
 ### SiMBA Datasets
@@ -105,9 +105,9 @@ Source: [GAMBA](https://github.com/DenuvoSoftwareSolutions/GAMBA)
 |--------|------:|
 | Total dataset lines | 72,647 |
 | Comment/header lines skipped | 2,063 |
-| Unparsable lines (e.g., `**` operator, no ground truth) | 1,012 |
-| **Parsed expressions** | **69,572** |
-| **Simplified** | **69,472** |
+| Unparsable lines (e.g., no ground truth) | 1,002 |
+| **Parsed expressions** | **69,582** |
+| **Simplified** | **69,482** |
 | Unsupported (by design) | 100 |
 | Errors / failures | **0** |
 

--- a/test/core/test_expr_parser.cpp
+++ b/test/core/test_expr_parser.cpp
@@ -395,6 +395,101 @@ TEST(ExprParserTest, RightShiftSmallBitwidth) {
     EXPECT_EQ(result.value().sig[0], 0xFu);
 }
 
+// --- Exponentiation (**) tests ---
+
+TEST(ExprParserTest, PowerSquare) {
+    auto result = ParseAndEvaluate("x ** 2", 64);
+    ASSERT_TRUE(result.has_value());
+    // x=0: 0, x=1: 1
+    EXPECT_EQ(result.value().sig[0], 0u);
+    EXPECT_EQ(result.value().sig[1], 1u);
+}
+
+TEST(ExprParserTest, PowerCube) {
+    auto result = ParseAndEvaluate("x ** 3", 8);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().sig[0], 0u);
+    EXPECT_EQ(result.value().sig[1], 1u);
+}
+
+TEST(ExprParserTest, PowerZero) {
+    auto result = ParseAndEvaluate("x ** 0", 64);
+    ASSERT_TRUE(result.has_value());
+    // x**0 = 1 for all x
+    EXPECT_EQ(result.value().sig[0], 1u);
+    EXPECT_EQ(result.value().sig[1], 1u);
+}
+
+TEST(ExprParserTest, PowerOne) {
+    auto result = ParseAndEvaluate("x ** 1", 64);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().sig[0], 0u);
+    EXPECT_EQ(result.value().sig[1], 1u);
+}
+
+TEST(ExprParserTest, PowerPrecedenceTighterThanMul) {
+    // x * y ** 2 should parse as x * (y**2), not (x*y)**2
+    auto result = ParseAndEvaluate("x * y ** 2", 64);
+    ASSERT_TRUE(result.has_value());
+    // x=0,y=0: 0*0=0; x=1,y=0: 1*0=0; x=0,y=1: 0*1=0; x=1,y=1: 1*1=1
+    EXPECT_EQ(result.value().sig[0], 0u);
+    EXPECT_EQ(result.value().sig[1], 0u);
+    EXPECT_EQ(result.value().sig[2], 0u);
+    EXPECT_EQ(result.value().sig[3], 1u);
+}
+
+TEST(ExprParserTest, RejectChainedPower) {
+    // Chained ** is rejected because the outer exponent is not a literal
+    auto result = ParseAndEvaluate("2 ** 2 ** 3", 64);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, CobraError::kParseError);
+}
+
+TEST(ExprParserTest, PowerInSubexpression) {
+    // 3*((x^y)**2) + 5*(x^y) — the motivating example from the issue
+    auto result = ParseAndEvaluate("3*((x^y)**2) + 5*(x^y)", 64);
+    ASSERT_TRUE(result.has_value());
+    // x=0,y=0: 3*0+5*0=0; x=1,y=0: 3*1+5*1=8;
+    // x=0,y=1: 3*1+5*1=8; x=1,y=1: 3*0+5*0=0
+    EXPECT_EQ(result.value().sig[0], 0u);
+    EXPECT_EQ(result.value().sig[1], 8u);
+    EXPECT_EQ(result.value().sig[2], 8u);
+    EXPECT_EQ(result.value().sig[3], 0u);
+}
+
+TEST(ExprParserTest, RejectVariableExponent) {
+    auto result = ParseAndEvaluate("x ** y", 64);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, CobraError::kParseError);
+}
+
+TEST(ExprParserTest, ParseToAstPowerSquare) {
+    auto result = ParseToAst("x ** 2", 64);
+    ASSERT_TRUE(result.has_value());
+    // x**2 expands to Mul(x, x)
+    EXPECT_EQ(result.value().expr->kind, Expr::Kind::kMul);
+    EXPECT_EQ(result.value().expr->children[0]->kind, Expr::Kind::kVariable);
+    EXPECT_EQ(result.value().expr->children[1]->kind, Expr::Kind::kVariable);
+}
+
+TEST(ExprParserTest, ParseToAstPowerZero) {
+    auto result = ParseToAst("x ** 0", 64);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().expr->kind, Expr::Kind::kConstant);
+    EXPECT_EQ(result.value().expr->constant_val, 1u);
+}
+
+TEST(ExprParserTest, ParseToAstRejectVariableExponent) {
+    auto result = ParseToAst("x ** y", 64);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, CobraError::kParseError);
+}
+
+TEST(ExprParserTest, PowerIsNonLinear) {
+    EXPECT_FALSE(IsLinearMba("x ** 2"));
+    EXPECT_FALSE(IsLinearMba("(x ^ y) ** 3"));
+}
+
 TEST(ExprParserTest, ParseToAstVariableIndex) {
     // Variables sorted lexicographically: a=0, b=1, x=2
     auto result = ParseToAst("a + b + x", 64);

--- a/test/verify/test_dataset_benchmarks.cpp
+++ b/test/verify/test_dataset_benchmarks.cpp
@@ -148,10 +148,9 @@ TEST(DatasetBenchmark, Multivariate64) {
 TEST(DatasetBenchmark, Permutation64) {
     auto stats = run_dataset(DATASET_DIR "/permutation64.txt");
     EXPECT_EQ(stats.total, 13);
-    // 10 lines use ** (unsupported by parser), 3 parse and simplify
-    EXPECT_EQ(stats.skipped_parse, 10);
-    EXPECT_EQ(stats.parsed, 3);
-    EXPECT_EQ(stats.simplified, 3);
+    EXPECT_EQ(stats.skipped_parse, 0);
+    EXPECT_EQ(stats.parsed, 13);
+    EXPECT_EQ(stats.simplified, 13);
     EXPECT_EQ(stats.unsupported, 0);
     EXPECT_EQ(stats.failed_simplify, 0);
 }

--- a/tools/cobra-cli/ExprParser.cpp
+++ b/tools/cobra-cli/ExprParser.cpp
@@ -135,7 +135,18 @@ namespace cobra {
                     continue;
                 }
 
-                // Two-character shift operators
+                // Two-character operators: **, <<, >>
+                if (expr[i] == '*' && i + 1 < expr.size() && expr[i + 1] == '*') {
+                    tokens.push_back(
+                        { .type        = TokenType::kOp,
+                          .value       = "**",
+                          .precedence  = 1,
+                          .right_assoc = true,
+                          .is_unary    = false }
+                    );
+                    i += 2;
+                    continue;
+                }
                 if (expr[i] == '<' && i + 1 < expr.size() && expr[i + 1] == '<') {
                     tokens.push_back(
                         { .type        = TokenType::kOp,
@@ -332,7 +343,27 @@ namespace cobra {
                         stack.pop();
                         auto lhs = std::move(stack.top());
                         stack.pop();
-                        if (tok.value == "<<" || tok.value == ">>") {
+                        if (tok.value == "**") {
+                            if (rhs->kind != Expr::Kind::kConstant) {
+                                return Err< std::unique_ptr< Expr > >(
+                                    CobraError::kParseError,
+                                    "unsupported: exponent must be "
+                                    "an integer literal"
+                                );
+                            }
+                            const uint64_t kExp = rhs->constant_val;
+                            if (kExp == 0) {
+                                stack.push(Expr::Constant(1ULL & mask));
+                            } else if (kExp == 1) {
+                                stack.push(std::move(lhs));
+                            } else {
+                                auto result = CloneExpr(*lhs);
+                                for (uint64_t p = 2; p <= kExp; ++p) {
+                                    result = Expr::Mul(std::move(result), CloneExpr(*lhs));
+                                }
+                                stack.push(std::move(result));
+                            }
+                        } else if (tok.value == "<<" || tok.value == ">>") {
                             if (rhs->kind != Expr::Kind::kConstant) {
                                 return Err< std::unique_ptr< Expr > >(
                                     CobraError::kParseError,
@@ -384,28 +415,39 @@ namespace cobra {
             return std::move(stack.top());
         }
 
-        Result< void > ValidateShifts(const std::vector< Token > &postfix, uint32_t bitwidth) {
+        Result< void > ValidateShiftsAndExponents(
+            const std::vector< Token > &postfix, uint32_t bitwidth
+        ) {
             for (size_t i = 0; i < postfix.size(); ++i) {
                 if (postfix[i].type != TokenType::kOp) { continue; }
-                if (postfix[i].value != "<<" && postfix[i].value != ">>") { continue; }
-                if (i == 0 || postfix[i - 1].type != TokenType::kNumber) {
-                    return Err< void >(
-                        CobraError::kParseError,
-                        "unsupported: shift amount must be "
-                        "an integer literal"
+                if (postfix[i].value == "<<" || postfix[i].value == ">>") {
+                    if (i == 0 || postfix[i - 1].type != TokenType::kNumber) {
+                        return Err< void >(
+                            CobraError::kParseError,
+                            "unsupported: shift amount must be "
+                            "an integer literal"
+                        );
+                    }
+                    uint64_t k = 0;
+                    std::from_chars(
+                        postfix[i - 1].value.data(),
+                        postfix[i - 1].value.data() + postfix[i - 1].value.size(), k
                     );
-                }
-                uint64_t k = 0;
-                std::from_chars(
-                    postfix[i - 1].value.data(),
-                    postfix[i - 1].value.data() + postfix[i - 1].value.size(), k
-                );
-                if (k >= bitwidth) {
-                    return Err< void >(
-                        CobraError::kParseError,
-                        "shift amount " + std::to_string(k) + " out of range for "
-                            + std::to_string(bitwidth) + "-bit mode"
-                    );
+                    if (k >= bitwidth) {
+                        return Err< void >(
+                            CobraError::kParseError,
+                            "shift amount " + std::to_string(k) + " out of range for "
+                                + std::to_string(bitwidth) + "-bit mode"
+                        );
+                    }
+                } else if (postfix[i].value == "**") {
+                    if (i == 0 || postfix[i - 1].type != TokenType::kNumber) {
+                        return Err< void >(
+                            CobraError::kParseError,
+                            "unsupported: exponent must be "
+                            "an integer literal"
+                        );
+                    }
                 }
             }
             return {};
@@ -440,7 +482,7 @@ namespace cobra {
         auto postfix = ToPostfix(*tokens);
         if (!postfix) { return std::unexpected(std::move(postfix.error())); }
 
-        auto shifts_ok = ValidateShifts(*postfix, bitwidth);
+        auto shifts_ok = ValidateShiftsAndExponents(*postfix, bitwidth);
         if (!shifts_ok) { return std::unexpected(std::move(shifts_ok.error())); }
 
         // Compile postfix into a compact form: resolve variable
@@ -456,6 +498,7 @@ namespace cobra {
             kXor,
             kShl,
             kShr,
+            kPow,
             kNot,
             kNeg
         };
@@ -524,6 +567,8 @@ namespace cobra {
                         op = CompiledOp::kShl;
                     } else if (tok.value == ">>") {
                         op = CompiledOp::kShr;
+                    } else if (tok.value == "**") {
+                        op = CompiledOp::kPow;
                     }
                     compiled.push_back({ .op = op, .operand = 0 });
                 }
@@ -588,6 +633,17 @@ namespace cobra {
                             case CompiledOp::kShr:
                                 r = (a >> b) & kMask;
                                 break;
+                            case CompiledOp::kPow: {
+                                uint64_t base = a & kMask;
+                                uint64_t exp  = b;
+                                r             = 1;
+                                while (exp > 0) {
+                                    if ((exp & 1) != 0) { r = (r * base) & kMask; }
+                                    base = (base * base) & kMask;
+                                    exp >>= 1;
+                                }
+                                break;
+                            }
                             default:
                                 break;
                         }
@@ -628,6 +684,7 @@ namespace cobra {
                     const bool lhs = has_var.top();
                     has_var.pop();
                     if (tok.value == "*" && lhs && rhs) { return false; }
+                    if (tok.value == "**" && lhs) { return false; }
                     has_var.push(lhs || rhs);
                 }
             }
@@ -660,7 +717,7 @@ namespace cobra {
         auto postfix = ToPostfix(*tokens);
         if (!postfix) { return std::unexpected(std::move(postfix.error())); }
 
-        auto shifts_ok = ValidateShifts(*postfix, bitwidth);
+        auto shifts_ok = ValidateShiftsAndExponents(*postfix, bitwidth);
         if (!shifts_ok) { return std::unexpected(std::move(shifts_ok.error())); }
 
         auto tree = BuildAstFromPostfix(*postfix, vars, bitwidth);


### PR DESCRIPTION
## Summary
- Add `**` as a binary operator in the expression parser (tightest precedence, right-associative, constant exponent required)
- All 13 `permutation64.txt` expressions now parse and simplify (previously 3/13 due to `**` being unrecognized)
- 12 new parser tests covering evaluation, AST construction, precedence, and error cases

Closes #1

## Test plan
- [x] All 858 existing tests pass (`ctest --test-dir build`)
- [x] 12 new `ExprParserTest.Power*` tests pass
- [x] `DatasetBenchmark.Permutation64` expects 13/13 parsed and simplified
- [x] `cobra-cli --mba "3*((x^y)**2) + 5*(x^y)"` parses and simplifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)