### PR TITLE
Release CompetitionGroup parent handle on no-emit join paths

### DIFF
--- a/lib/core/CompetitionGroup.cpp
+++ b/lib/core/CompetitionGroup.cpp
@@ -70,7 +70,13 @@ namespace cobra {
         // resolved and been erased; treat the late release as a no-op.
         if (it == groups.end()) { return std::nullopt; }
         auto &group = it->second;
+        // Defensive: a buggy caller that double-releases would
+        // wrap open_handles past zero and wedge the group forever
+        // (it would never reach 0 again). Treat double-release as a
+        // no-op here so the bug is contained, and assert in debug
+        // builds so we still notice during development.
         assert(group.open_handles > 0);
+        if (group.open_handles == 0) { return std::nullopt; }
 
         --group.open_handles;
         if (group.open_handles > 0) { return std::nullopt; }

--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -1128,6 +1128,26 @@ namespace cobra {
                     item.depth = item.depth + 2;
                     worklist.Push(std::move(item));
                 }
+                // CONTRACT (handle transfer on kConsumeCurrent + advance):
+                // Passes that return kAdvance / kSolvedCandidate +
+                // kConsumeCurrent on an item with item.group_id MUST
+                // transfer the handle. Three patterns are valid:
+                //   1. A child in pr.next inherits item.group_id
+                //      (e.g., RunClassifyAst). The child's lifecycle
+                //      eventually releases.
+                //   2. The pass stores item.group_id in a JoinState
+                //      (e.g., RunOperandSimplify, RunProductIdentity-
+                //      Collapse) so the matching Resolve* releases it.
+                //   3. The pass acquires a fresh handle on item.group_id
+                //      and stores it in a continuation, with the matching
+                //      resolver releasing.
+                // The main loop deliberately does NOT release here
+                // because doing so would break (1)–(3). Any new pass
+                // emitting kConsumeCurrent on a grouped item without
+                // one of these patterns LEAKS the parent group's
+                // handle, wedging that group permanently. The
+                // kBlocked/kNoProgress branch below DOES release
+                // because it has no transfer mechanism.
             } else {
                 // kBlocked / kNoProgress
                 if (!pr.reason.top.message.empty()) { item.metadata.last_failure = pr.reason; }

--- a/lib/core/SignaturePasses.cpp
+++ b/lib/core/SignaturePasses.cpp
@@ -459,8 +459,7 @@ namespace cobra {
             // unconditional release in ResolveBitwiseCompose /
             // ResolveHybridCompose; the difference is we have a join.
             if (pr.next.empty() && parent_group_id.has_value()) {
-                auto parent_resolved =
-                    ReleaseHandle(ctx.competition_groups, *parent_group_id);
+                auto parent_resolved = ReleaseHandle(ctx.competition_groups, *parent_group_id);
                 if (parent_resolved.has_value()) {
                     pr.next.push_back(std::move(*parent_resolved));
                 }
@@ -532,8 +531,7 @@ namespace cobra {
             // path. Mirror ResolveBitwiseCompose / ResolveHybridCompose,
             // which always release because they have no join.
             if (pr.next.empty() && parent_group_id.has_value()) {
-                auto parent_resolved =
-                    ReleaseHandle(ctx.competition_groups, *parent_group_id);
+                auto parent_resolved = ReleaseHandle(ctx.competition_groups, *parent_group_id);
                 if (parent_resolved.has_value()) {
                     pr.next.push_back(std::move(*parent_resolved));
                 }

--- a/lib/core/SignaturePasses.cpp
+++ b/lib/core/SignaturePasses.cpp
@@ -446,9 +446,26 @@ namespace cobra {
                 );
             }
 
+            const auto parent_group_id = join->parent_group_id;
             if (best.has_value()) { EmitJoinRewrite(*join, item, std::move(best->expr), pr); }
 
             ctx.join_states.erase(join_it);
+
+            // No rewrite emitted: release the parent handle that the
+            // join was pinning. The success path transfers the handle
+            // to the rewritten item via EmitJoinRewrite (which sets
+            // rewritten.group_id = join.parent_group_id), so we only
+            // release here when no rewrite was pushed. Mirror the
+            // unconditional release in ResolveBitwiseCompose /
+            // ResolveHybridCompose; the difference is we have a join.
+            if (pr.next.empty() && parent_group_id.has_value()) {
+                auto parent_resolved =
+                    ReleaseHandle(ctx.competition_groups, *parent_group_id);
+                if (parent_resolved.has_value()) {
+                    pr.next.push_back(std::move(*parent_resolved));
+                }
+            }
+
             return pr;
         }
 
@@ -505,7 +522,23 @@ namespace cobra {
                 }
             }
 
+            const auto parent_group_id = join->parent_group_id;
             ctx.join_states.erase(join_it);
+
+            // No rewrite emitted: release the parent handle that the
+            // join was pinning. EmitJoinRewrite transfers the handle
+            // to the rewritten item by setting rewritten.group_id =
+            // join.parent_group_id, so we only release on the no-emit
+            // path. Mirror ResolveBitwiseCompose / ResolveHybridCompose,
+            // which always release because they have no join.
+            if (pr.next.empty() && parent_group_id.has_value()) {
+                auto parent_resolved =
+                    ReleaseHandle(ctx.competition_groups, *parent_group_id);
+                if (parent_resolved.has_value()) {
+                    pr.next.push_back(std::move(*parent_resolved));
+                }
+            }
+
             return pr;
         }
 

--- a/test/core/test_competition_group.cpp
+++ b/test/core/test_competition_group.cpp
@@ -189,6 +189,30 @@ TEST(CompetitionGroup, ReleaseMissingGroupReturnsNullopt) {
     EXPECT_FALSE(ReleaseHandle(groups, 42).has_value());
 }
 
+// Regression: orchestrator-core-7. A double release on a group whose
+// open_handles already reached zero must not wrap uint32 past zero
+// (which would wedge the group forever — count never returns to 0,
+// candidates pile up undelivered). Treat the second release as a
+// no-op instead.
+#ifdef NDEBUG
+TEST(CompetitionGroup, DoubleReleaseDoesNotWrapPastZero) {
+    absl::flat_hash_map< GroupId, CompetitionGroup > groups;
+    GroupId next_id = 0;
+    auto id         = CreateGroup(groups, next_id);
+
+    auto first = ReleaseHandle(groups, id);
+    ASSERT_TRUE(first.has_value());
+    // The group is conceptually resolved but still in the map until
+    // the orchestrator processes the resolved item; a stray second
+    // release must not corrupt open_handles.
+    EXPECT_EQ(groups.at(id).open_handles, 0);
+
+    auto second = ReleaseHandle(groups, id);
+    EXPECT_FALSE(second.has_value());
+    EXPECT_EQ(groups.at(id).open_handles, 0);
+}
+#endif
+
 // --- State model integration tests ---
 
 TEST(CompetitionGroup, GetStateKindForResolved) {

--- a/test/core/test_signature_passes.cpp
+++ b/test/core/test_signature_passes.cpp
@@ -1180,6 +1180,152 @@ TEST(SignaturePass, OperandJoinResolveBothSides) {
     EXPECT_EQ(pr.next[0].rewrite_gen, 1u);
 }
 
+// Regression: orchestrator-core-cross-3. When both operand-rewrite
+// children resolve with no winner, the parent group's handle (pinned
+// by the join) must be released. Before the fix, ResolveOperandRewrite
+// returned without releasing, leaving the parent group wedged with
+// open_handles=1 forever — its continuation would never fire and any
+// downstream lineage starves.
+TEST(SignaturePass, OperandJoinResolveNoWinnerReleasesParentHandle) {
+    std::vector< std::string > vars = { "x0", "x1" };
+    Options opts;
+    opts.bitwidth   = 64;
+    auto ctx        = MakeCtx(opts, vars);
+    auto parent_gid = CreateGroup(ctx.competition_groups, ctx.next_group_id);
+    EXPECT_EQ(ctx.competition_groups.at(parent_gid).open_handles, 1u);
+
+    auto orig_mul = Expr::Mul(Expr::Variable(0), Expr::Variable(1));
+
+    OperandJoinState join;
+    join.full_ast        = CloneExpr(*orig_mul);
+    join.original_mul    = CloneExpr(*orig_mul);
+    join.target_hash     = std::hash< Expr >{}(*orig_mul);
+    join.baseline_cost   = ComputeCost(*orig_mul).cost;
+    join.vars            = vars;
+    join.parent_group_id = parent_gid;
+    join.bitwidth        = 64;
+    join.parent_depth    = 0;
+    join.rewrite_gen     = 0;
+
+    auto join_id = CreateJoin(ctx.join_states, ctx.next_join_id, JoinState{ std::move(join) });
+
+    // LHS child group resolves with NO submitted candidate (winner stays empty).
+    auto lhs_gid = CreateGroup(ctx.competition_groups, ctx.next_group_id);
+    ctx.competition_groups.at(lhs_gid).continuation = ContinuationData{
+        OperandRewriteCont{
+                           .join_id = join_id,
+                           .role    = OperandRewriteCont::OperandRole::kLhs,
+                           }
+    };
+    WorkItem lhs_resolved;
+    lhs_resolved.payload = CompetitionResolvedPayload{ .group_id = lhs_gid };
+    auto r1              = RunResolveCompetition(lhs_resolved, ctx);
+    ASSERT_TRUE(r1.has_value());
+    // Parent handle still pinned at this point (RHS hasn't resolved).
+    EXPECT_EQ(ctx.competition_groups.at(parent_gid).open_handles, 1u);
+
+    // RHS child group: same — resolves with no winner.
+    auto rhs_gid = CreateGroup(ctx.competition_groups, ctx.next_group_id);
+    ctx.competition_groups.at(rhs_gid).continuation = ContinuationData{
+        OperandRewriteCont{
+                           .join_id = join_id,
+                           .role    = OperandRewriteCont::OperandRole::kRhs,
+                           }
+    };
+    WorkItem rhs_resolved;
+    rhs_resolved.payload = CompetitionResolvedPayload{ .group_id = rhs_gid };
+    auto r2              = RunResolveCompetition(rhs_resolved, ctx);
+    ASSERT_TRUE(r2.has_value());
+
+    // Join is cleaned up.
+    EXPECT_EQ(ctx.join_states.count(join_id), 0u);
+
+    // Parent group's handle must be released (regression: cross-3).
+    // Before the fix, open_handles was still 1 — the leak.
+    // The group is still in the map until the orchestrator processes
+    // the CompetitionResolvedPayload via RunResolveCompetition.
+    ASSERT_EQ(ctx.competition_groups.count(parent_gid), 1u);
+    EXPECT_EQ(ctx.competition_groups.at(parent_gid).open_handles, 0u);
+
+    // The resolver must surface a CompetitionResolvedPayload for the
+    // parent so the orchestrator can fire its continuation.
+    bool found_parent_resolved = false;
+    for (const auto &n : r2->next) {
+        if (const auto *p = std::get_if< CompetitionResolvedPayload >(&n.payload)) {
+            if (p->group_id == parent_gid) { found_parent_resolved = true; }
+        }
+    }
+    EXPECT_TRUE(found_parent_resolved);
+}
+
+// Regression: orchestrator-core-cross-3 (ProductCollapse variant).
+// Same shape as above for ResolveProductCollapse: when both factors
+// resolve with no winner, parent handle must be released.
+TEST(SignaturePass, ProductJoinResolveNoWinnerReleasesParentHandle) {
+    std::vector< std::string > vars = { "x0", "x1" };
+    Options opts;
+    opts.bitwidth   = 64;
+    auto ctx        = MakeCtx(opts, vars);
+    auto parent_gid = CreateGroup(ctx.competition_groups, ctx.next_group_id);
+    EXPECT_EQ(ctx.competition_groups.at(parent_gid).open_handles, 1u);
+
+    auto orig = Expr::Add(
+        Expr::Mul(Expr::Variable(0), Expr::Variable(1)),
+        Expr::Mul(Expr::Variable(0), Expr::Variable(1))
+    );
+
+    ProductJoinState join;
+    join.original_expr   = CloneExpr(*orig);
+    join.baseline_cost   = ComputeCost(*orig).cost;
+    join.vars            = vars;
+    join.parent_group_id = parent_gid;
+    join.bitwidth        = 64;
+    join.parent_depth    = 0;
+    join.rewrite_gen     = 0;
+    join.full_ast        = CloneExpr(*orig);
+    join.target_hash     = std::hash< Expr >{}(*orig);
+
+    auto join_id = CreateJoin(ctx.join_states, ctx.next_join_id, JoinState{ std::move(join) });
+
+    auto x_gid = CreateGroup(ctx.competition_groups, ctx.next_group_id);
+    ctx.competition_groups.at(x_gid).continuation = ContinuationData{
+        ProductCollapseCont{
+                            .join_id = join_id,
+                            .role    = ProductCollapseCont::FactorRole::kX,
+                            }
+    };
+    WorkItem x_resolved;
+    x_resolved.payload = CompetitionResolvedPayload{ .group_id = x_gid };
+    auto r1            = RunResolveCompetition(x_resolved, ctx);
+    ASSERT_TRUE(r1.has_value());
+    EXPECT_EQ(ctx.competition_groups.at(parent_gid).open_handles, 1u);
+
+    auto y_gid = CreateGroup(ctx.competition_groups, ctx.next_group_id);
+    ctx.competition_groups.at(y_gid).continuation = ContinuationData{
+        ProductCollapseCont{
+                            .join_id = join_id,
+                            .role    = ProductCollapseCont::FactorRole::kY,
+                            }
+    };
+    WorkItem y_resolved;
+    y_resolved.payload = CompetitionResolvedPayload{ .group_id = y_gid };
+    auto r2            = RunResolveCompetition(y_resolved, ctx);
+    ASSERT_TRUE(r2.has_value());
+
+    EXPECT_EQ(ctx.join_states.count(join_id), 0u);
+    // Parent group's handle must be released (regression: cross-3).
+    ASSERT_EQ(ctx.competition_groups.count(parent_gid), 1u);
+    EXPECT_EQ(ctx.competition_groups.at(parent_gid).open_handles, 0u);
+
+    bool found_parent_resolved = false;
+    for (const auto &n : r2->next) {
+        if (const auto *p = std::get_if< CompetitionResolvedPayload >(&n.payload)) {
+            if (p->group_id == parent_gid) { found_parent_resolved = true; }
+        }
+    }
+    EXPECT_TRUE(found_parent_resolved);
+}
+
 // --- ProductCollapseCont resolution tests ---
 
 TEST(SignaturePass, ProductJoinResolveBothFactors) {


### PR DESCRIPTION
## Summary

Fixes three related findings in the CompetitionGroup handle/refcount cluster surfaced by `/vivisect`.

- `ResolveOperandRewrite` (`lib/core/SignaturePasses.cpp`) and `ResolveProductCollapse` returned without releasing the parent group's handle when no candidate was emitted (both children resolved without winners, or `FullWidthCheck` rejected the recombined candidate). Sibling resolvers `ResolveBitwiseCompose` and `ResolveHybridCompose` always release; the asymmetry left parent groups wedged with `open_handles=1` forever, their continuations never fired, and dependent lineage starved.
- `ReleaseHandle` (`lib/core/CompetitionGroup.cpp`) only guarded against double-release with a debug-only `assert`. Release builds would wrap `open_handles` past zero to `UINT32_MAX`, permanently wedging the group with no diagnostic. Replaced with a runtime early-return so the bug is contained while the assert still fires in debug builds during development.
- Documented the handle-transfer contract on the `kAdvance`/`kSolvedCandidate` + `kConsumeCurrent` branch in the orchestrator main loop so future passes don't reintroduce the leak. The main loop deliberately does not release here because passes either (1) inherit `group_id` to a child in `pr.next`, (2) store it in a `JoinState`, or (3) acquire a fresh handle on a continuation. Any new pass emitting `kConsumeCurrent` on a grouped item without one of these patterns leaks.

## Test plan

- [x] `test_competition_group.DoubleReleaseDoesNotWrapPastZero` (release-build only) — verifies the runtime guard.
- [x] `test_signature_passes.OperandJoinResolveNoWinnerReleasesParentHandle` — verifies the no-winner path now decrements the parent handle and surfaces a `CompetitionResolvedPayload`.
- [x] `test_signature_passes.ProductJoinResolveNoWinnerReleasesParentHandle` — same shape for `ResolveProductCollapse`.
- [x] All 1166 existing unit tests still pass (dataset benchmarks excluded with `-E "Dataset|dataset"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)