### PR TITLE
Mark SeedNoAst constant fast-path unverified when evaluator absent

### DIFF
--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -733,6 +733,20 @@ namespace cobra {
 
             auto original_indices = BuildVarSupport(vars, elim.real_vars);
 
+            // Mirror RunBuildSignatureState: when an evaluator is
+            // available, downstream candidates MUST be lifted back to
+            // the original variable space and re-checked there
+            // (VerifyInOriginalSpace). Hardcoding this flag to false
+            // bypassed verification entirely on the no-AST seed path:
+            // a Dirac signature (zero on {0,1}^n, nonzero at full
+            // width) would round-trip as a verified Constant(0)
+            // because the boolean-domain AuxVarEliminator collapses
+            // real_vars to empty, the remapped evaluator pins all
+            // dropped vars to 0 (where the Dirac function also
+            // evaluates to 0), and the orchestrator accepted the
+            // candidate without consulting the original evaluator.
+            bool needs_verification = ctx.evaluator.has_value();
+
             WorkItem sig_seed;
             sig_seed.payload = SignatureStatePayload{
                 .ctx = {
@@ -740,7 +754,7 @@ namespace cobra {
                     .real_vars                         = elim.real_vars,
                     .elimination                       = std::move(elim),
                     .original_indices                  = std::move(original_indices),
-                    .needs_original_space_verification = false,
+                    .needs_original_space_verification = needs_verification,
                 },
             };
             sig_seed.features.provenance = Provenance::kOriginal;

--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -680,23 +680,37 @@ namespace cobra {
             // at full width.  Dirac expressions (zero on {0,1} but
             // nonzero at a single full-width point) would otherwise
             // be emitted as constant 0 without any full-width check.
+            //
+            // Verification contract: the result is marked kVerified
+            // ONLY when an evaluator confirmed it at full width. With
+            // no evaluator (no-AST + opts.evaluator unset), we still
+            // accept the constant — it is correct on {0,1}^n by sig
+            // construction — but mark it kUnverified so the caller
+            // knows we never checked the full-width domain. Setting
+            // kVerified in the no-evaluator branch was the silent-
+            // accept bug: a Dirac sig would be emitted as Constant(0)
+            // with verified=true.
             auto pm = MatchPattern(sig, num_vars, ctx.bitwidth);
             if (pm && (*pm)->kind == Expr::Kind::kConstant) {
-                bool fw_ok = true;
+                bool fw_ok       = true;
+                bool fw_verified = false;
                 if (ctx.evaluator) {
                     auto check =
                         FullWidthCheckEval(*ctx.evaluator, num_vars, **pm, ctx.bitwidth);
-                    fw_ok = check.passed;
+                    fw_ok       = check.passed;
+                    fw_verified = check.passed;
                 }
                 if (fw_ok) {
                     ItemMetadata meta;
-                    meta.sig_vector   = sig;
-                    meta.verification = VerificationState::kVerified;
+                    meta.sig_vector = sig;
+                    meta.verification =
+                        fw_verified ? VerificationState::kVerified
+                                    : VerificationState::kUnverified;
 
                     return Ok(
                         std::optional< OrchestratorResult >(OrchestratorResult{
                             .outcome = PassOutcome::Success(
-                                std::move(*pm), {}, VerificationState::kVerified
+                                std::move(*pm), {}, meta.verification
                             ),
                             .metadata     = std::move(meta),
                             .run_metadata = ctx.run_metadata,

--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -702,16 +702,14 @@ namespace cobra {
                 }
                 if (fw_ok) {
                     ItemMetadata meta;
-                    meta.sig_vector = sig;
-                    meta.verification =
-                        fw_verified ? VerificationState::kVerified
-                                    : VerificationState::kUnverified;
+                    meta.sig_vector   = sig;
+                    meta.verification = fw_verified ? VerificationState::kVerified
+                                                    : VerificationState::kUnverified;
 
                     return Ok(
                         std::optional< OrchestratorResult >(OrchestratorResult{
-                            .outcome = PassOutcome::Success(
-                                std::move(*pm), {}, meta.verification
-                            ),
+                            .outcome =
+                                PassOutcome::Success(std::move(*pm), {}, meta.verification),
                             .metadata     = std::move(meta),
                             .run_metadata = ctx.run_metadata,
                         })

--- a/test/core/test_simplifier.cpp
+++ b/test/core/test_simplifier.cpp
@@ -12,7 +12,13 @@
 
 using namespace cobra;
 
-TEST(SimplifierTest, ConstantMBA) {
+TEST(SimplifierTest, ConstantMBA_NoEvaluator) {
+    // No-AST + no-evaluator path: the constant fast-path matches the
+    // boolean signature but cannot prove correctness at full width
+    // (a Dirac-shaped sig would silently round-trip as Constant(0)
+    // with verified=true under the old behavior). The simplification
+    // is still emitted — it is correct on {0,1}^n by construction —
+    // but verified must be false because no full-width check ran.
     std::vector< uint64_t > sig     = { 42, 42, 42, 42 };
     std::vector< std::string > vars = { "x", "y" };
     Options opts{ .bitwidth = 64, .max_vars = 16, .spot_check = true };
@@ -20,8 +26,56 @@ TEST(SimplifierTest, ConstantMBA) {
     auto result = Simplify(sig, vars, nullptr, opts);
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(Render(*result.value().expr, result.value().real_vars), "42");
+    EXPECT_FALSE(result.value().verified);
+}
+
+TEST(SimplifierTest, ConstantMBA_WithEvaluator) {
+    // Same input but with an evaluator that confirms 42 at full width:
+    // the constant fast-path runs FullWidthCheckEval and marks the
+    // result verified.
+    std::vector< uint64_t > sig     = { 42, 42, 42, 42 };
+    std::vector< std::string > vars = { "x", "y" };
+    Options opts{
+        .bitwidth   = 64,
+        .max_vars   = 16,
+        .spot_check = true,
+        .evaluator  = [](const std::vector< uint64_t > &) -> uint64_t { return 42; },
+    };
+
+    auto result = Simplify(sig, vars, nullptr, opts);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(Render(*result.value().expr, result.value().real_vars), "42");
     EXPECT_TRUE(result.value().verified);
 }
+
+// Regression: orchestrator-core-5. A Dirac-shaped sig (zero on
+// {0,1}^n, nonzero at a single full-width point) used to round-trip
+// as Constant(0) with verified=true. With the fix, the constant
+// fast-path still emits Constant(0) (correct on the boolean domain)
+// but verified is false; an evaluator that reveals the Dirac point
+// rejects the candidate outright via FullWidthCheckEval.
+TEST(SimplifierTest, DiracSigNoEvaluatorIsNotMarkedVerified) {
+    // sig is zero on {0,1}^1 — boolean-equivalent to Constant(0).
+    std::vector< uint64_t > sig     = { 0, 0 };
+    std::vector< std::string > vars = { "x" };
+    Options opts{ .bitwidth = 64, .max_vars = 16, .spot_check = true };
+
+    auto result = Simplify(sig, vars, nullptr, opts);
+    ASSERT_TRUE(result.has_value());
+    // The boolean answer is still emitted (correct on {0,1}).
+    EXPECT_EQ(Render(*result.value().expr, result.value().real_vars), "0");
+    // ...but no full-width verification was possible.
+    EXPECT_FALSE(result.value().verified);
+}
+
+// Note: a stronger test would prove that with a Dirac-revealing
+// evaluator (e.g. v[0]*(v[0]-1), which is zero on {0,1} but non-
+// zero at v[0]=2), Simplify never returns a verified Constant(0).
+// Such a test currently still fails because downstream pipeline
+// stages (outside SeedNoAst's constant fast-path) have analogous
+// silent-accept patterns that should be audited separately. This
+// fix addresses only the SeedNoAst gate documented in
+// orchestrator-core-5.
 
 TEST(SimplifierTest, XPlusY) {
     std::vector< uint64_t > sig     = { 0, 1, 1, 2 };
@@ -192,6 +246,9 @@ TEST(SimplifierTest, SpotCheckFalse) {
 
 // All-zero sig through full pipeline
 TEST(SimplifierTest, AllZeroSig) {
+    // Mirror of ConstantMBA_NoEvaluator for the zero-constant case:
+    // the boolean answer is correct but unverified at full width
+    // without an evaluator (see orchestrator-core-5).
     std::vector< uint64_t > sig     = { 0, 0, 0, 0 };
     std::vector< std::string > vars = { "x", "y" };
     Options opts{ .bitwidth = 64, .max_vars = 16, .spot_check = true };
@@ -199,7 +256,7 @@ TEST(SimplifierTest, AllZeroSig) {
     auto result = Simplify(sig, vars, nullptr, opts);
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(Render(*result.value().expr, result.value().real_vars), "0");
-    EXPECT_TRUE(result.value().verified);
+    EXPECT_FALSE(result.value().verified);
 }
 
 // Bitwidth=8 through full pipeline with wrapping

--- a/test/core/test_simplifier.cpp
+++ b/test/core/test_simplifier.cpp
@@ -83,8 +83,9 @@ TEST(SimplifierTest, DiracSigWithEvaluatorRejectsConstantFastPath) {
         .bitwidth   = 64,
         .max_vars   = 16,
         .spot_check = true,
-        .evaluator =
-            [](const std::vector< uint64_t > &v) -> uint64_t { return v[0] * (v[0] - 1); },
+        .evaluator  = [](const std::vector< uint64_t > &v) -> uint64_t {
+            return v[0] * (v[0] - 1);
+        },
     };
 
     auto result = Simplify(sig, vars, nullptr, opts);
@@ -93,13 +94,8 @@ TEST(SimplifierTest, DiracSigWithEvaluatorRejectsConstantFastPath) {
     // It may legitimately fail to simplify (kUnchangedUnsupported) or
     // emit some non-zero candidate; what's forbidden is the lying
     // "verified Constant(0)" combination.
-    if (result->kind == SimplifyOutcome::Kind::kSimplified
-        && result->expr != nullptr)
-    {
-        EXPECT_FALSE(
-            result->verified
-            && Render(*result->expr, result->real_vars) == "0"
-        );
+    if (result->kind == SimplifyOutcome::Kind::kSimplified && result->expr != nullptr) {
+        EXPECT_FALSE(result->verified && Render(*result->expr, result->real_vars) == "0");
     }
 }
 

--- a/test/core/test_simplifier.cpp
+++ b/test/core/test_simplifier.cpp
@@ -68,14 +68,40 @@ TEST(SimplifierTest, DiracSigNoEvaluatorIsNotMarkedVerified) {
     EXPECT_FALSE(result.value().verified);
 }
 
-// Note: a stronger test would prove that with a Dirac-revealing
-// evaluator (e.g. v[0]*(v[0]-1), which is zero on {0,1} but non-
-// zero at v[0]=2), Simplify never returns a verified Constant(0).
-// Such a test currently still fails because downstream pipeline
-// stages (outside SeedNoAst's constant fast-path) have analogous
-// silent-accept patterns that should be audited separately. This
-// fix addresses only the SeedNoAst gate documented in
-// orchestrator-core-5.
+// Regression: pipeline-wide silent-accept on Dirac sigs. The
+// SeedNoAst constant fast-path is corrected by the test above, but
+// downstream pipeline stages historically also produced
+// kVerified Constant(0) for a boolean-zero sig even when the
+// evaluator disagreed at full width. With the evaluator returning
+// v[0]*(v[0]-1) (zero on {0,1} but non-zero at v[0]=2), no
+// candidate emitted by Simplify may be both verified and
+// structurally Constant(0).
+TEST(SimplifierTest, DiracSigWithEvaluatorRejectsConstantFastPath) {
+    std::vector< uint64_t > sig     = { 0, 0 };
+    std::vector< std::string > vars = { "x" };
+    Options opts{
+        .bitwidth   = 64,
+        .max_vars   = 16,
+        .spot_check = true,
+        .evaluator =
+            [](const std::vector< uint64_t > &v) -> uint64_t { return v[0] * (v[0] - 1); },
+    };
+
+    auto result = Simplify(sig, vars, nullptr, opts);
+    ASSERT_TRUE(result.has_value());
+    // The pipeline must NOT silently emit a verified Constant(0).
+    // It may legitimately fail to simplify (kUnchangedUnsupported) or
+    // emit some non-zero candidate; what's forbidden is the lying
+    // "verified Constant(0)" combination.
+    if (result->kind == SimplifyOutcome::Kind::kSimplified
+        && result->expr != nullptr)
+    {
+        EXPECT_FALSE(
+            result->verified
+            && Render(*result->expr, result->real_vars) == "0"
+        );
+    }
+}
 
 TEST(SimplifierTest, XPlusY) {
     std::vector< uint64_t > sig     = { 0, 1, 1, 2 };


### PR DESCRIPTION
## Summary

Two related silent-accept bugs on the no-AST seed path. Both let a Dirac-shaped signature (zero on `{0,1}^n`, nonzero at full width) round-trip as a verified `Constant(0)` even when the caller had supplied an evaluator that would have rejected it.

### Bug 1: `SeedNoAst` constant fast-path (commit 474821c)

`SeedNoAst`'s constant fast-path returned the matched constant with `verification=kVerified` even when `ctx.evaluator` was unset. The fix marks `kVerified` only when `FullWidthCheckEval` ran and passed; `kUnverified` when no evaluator was available.

### Bug 2: `SeedNoAst` general path (commit 7aaa5af)

After Bug 1 was fixed, the general SignatureStatePayload pushed for the rest of the pipeline still hardcoded `needs_original_space_verification = false`, so candidates emitted by downstream stages (`RunSignaturePatternMatch`, the boolean-ANF fast path, etc.) were accepted directly at `Orchestrator.cpp:1028` without re-checking against the caller's evaluator.

The damage was concrete:
- `AuxVarEliminator` collapses `real_vars` to empty (the boolean function IS constant 0 on `{0,1}`).
- The orchestrator builds a remapped evaluator that pins all dropped vars to 0 — where the Dirac function also evaluates to 0.
- The remapped FW check trivially passes against `Constant(0)` because it's checking the function only at points where it agrees.
- The candidate is accepted with `verified=true` despite the original evaluator rejecting it at `v[0]=2`.

Fix mirrors `RunBuildSignatureState`'s `needs_verification = active_eval.has_value()` so candidates from the no-AST path get lifted to the original variable space and re-checked via `VerifyInOriginalSpace`, which catches the Dirac mismatch and surfaces `kUnchangedUnsupported` instead.

## Test plan

- [x] `ConstantMBA_NoEvaluator` — constant fast-path with no evaluator → `verified=false`.
- [x] `ConstantMBA_WithEvaluator` — same input + evaluator that confirms 42 → `verified=true`.
- [x] `DiracSigNoEvaluatorIsNotMarkedVerified` — boolean-zero sig, no evaluator → `verified=false`.
- [x] `DiracSigWithEvaluatorRejectsConstantFastPath` — boolean-zero sig + Dirac-revealing evaluator → never returns `verified Constant(0)` (now `kUnchangedUnsupported`).
- [x] `AllZeroSig` updated to match the corrected contract.
- [x] All 1166 existing unit tests still pass (dataset benchmarks excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)