### PR TITLE
Cap Simplify input vars at kMaxInputVars=24 to bound 2^N work

### DIFF
--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -856,12 +856,43 @@ namespace cobra {
 
     } // namespace
 
+    // Upper bound on the number of input variables the orchestrator
+    // will accept before any signature work runs. The sig pipeline is
+    // O(2^vars.size()) in both time and space (kLen = 1 << num_vars
+    // in EvaluateBooleanSignature, plus follow-on passes that walk
+    // the sig), so an unbounded vars.size() is a DoS vector — a
+    // caller can request 2^40 entries and OOM the process before any
+    // max_vars policy check fires (those checks happen on the
+    // post-AuxVarEliminator real_vars count, which presupposes the
+    // sig has already been computed). 24 caps the sig at ~16M
+    // entries (~128 MiB) which is well above the 6-8 vars used by
+    // the existing test corpus, the 20-var kMaxPolyVars ceiling, and
+    // the 16-var default opts.max_vars policy.
+    inline constexpr uint32_t kMaxInputVars = 24;
+
     Result< SimplifyOutcome > Simplify(
         const std::vector< uint64_t > &sig, const std::vector< std::string > &vars,
         const Expr *input_expr, const Options &opts
     ) {
         COBRA_ZONE_N("Simplify");
         COBRA_ZONE_VALUE(static_cast< int64_t >(vars.size()));
+
+        // Reject pathological input-variable counts before any
+        // 2^vars.size() signature allocation runs. Without this gate
+        // the with-AST path computes EvaluateBooleanSignature in
+        // RunBuildSignatureState (and the dynamic-mask shortcut just
+        // below) before reaching the post-elimination max_vars check,
+        // turning any caller-supplied vars.size() into an unbounded
+        // memory request.
+        if (vars.size() > kMaxInputVars) {
+            return Err< SimplifyOutcome >(
+                CobraError::kTooManyVariables,
+                "Input variable count (" + std::to_string(vars.size())
+                    + ") exceeds kMaxInputVars (" + std::to_string(kMaxInputVars)
+                    + "); a 2^vars.size() signature would exceed memory bounds. "
+                      "Reduce vars or pre-eliminate aux variables before calling Simplify."
+            );
+        }
 
         // Dynamic masking: if the root is (2^m - 1) & g and g contains
         // no right shifts, try solving g under bitwidth=m. Modular

--- a/test/core/test_simplifier.cpp
+++ b/test/core/test_simplifier.cpp
@@ -1802,3 +1802,37 @@ TEST(SimplifierTest, DynamicMask_4bit_Constant) {
     auto check = FullWidthCheckEval(eval, 1, *result->expr, 64);
     EXPECT_TRUE(check.passed);
 }
+
+// Regression: orchestrator-core-8. RunBuildSignatureState computed
+// the boolean signature (size 2^vars.size()) before checking the
+// max_vars policy, so a caller could request 2^40 entries and OOM
+// the process. The fix rejects pathological vars.size() up front
+// with kTooManyVariables, before any 2^N work runs.
+TEST(SimplifierTest, RejectsExcessiveInputVarCount) {
+    // 25 variables — one over kMaxInputVars=24. Signature would be
+    // 2^25 = 33M entries (~256 MiB). The pre-check must reject before
+    // any allocation.
+    std::vector< std::string > vars;
+    for (int i = 0; i < 25; ++i) { vars.push_back("x" + std::to_string(i)); }
+    std::vector< uint64_t > sig(2, 0);  // size doesn't matter; rejected first
+    Options opts{ .bitwidth = 64, .max_vars = 16, .spot_check = false };
+
+    auto result = Simplify(sig, vars, nullptr, opts);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, CobraError::kTooManyVariables);
+}
+
+TEST(SimplifierTest, AcceptsInputVarCountAtCeiling) {
+    // Exactly kMaxInputVars=24. The pre-check is `>` so this must
+    // pass through to the normal pipeline. Constant sig of correct
+    // length so AuxVarEliminator collapses to 0 real vars and the
+    // downstream max_vars policy is satisfied.
+    std::vector< std::string > vars;
+    for (int i = 0; i < 24; ++i) { vars.push_back("x" + std::to_string(i)); }
+    std::vector< uint64_t > sig(size_t{ 1 } << vars.size(), 7);
+    Options opts{ .bitwidth = 64, .max_vars = 16, .spot_check = false };
+
+    auto result = Simplify(sig, vars, nullptr, opts);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(Render(*result.value().expr, result.value().real_vars), "7");
+}


### PR DESCRIPTION
## Summary

Fixes `orchestrator-core-8` from the `/vivisect` audit.

`RunBuildSignatureState` computes the boolean signature of size `2^vars.size()` (`kLen = 1 << num_vars` in `EvaluateBooleanSignature`) before reaching the post-`AuxVarEliminator` `max_vars` policy check. A caller passing `vars.size()=40` triggers a 2^40-entry allocation (~9 TB) before any guard fires; `vars.size()=33` triggers a 2^33 allocation (~64 GB). Either OOMs the process before the policy even gets to look at the result. Same surface in the dynamic-mask shortcut at the top of `Simplify` (`EvaluateBooleanSignature(*inner, vars.size(), eff_bw)`).

Add a `kMaxInputVars=24` ceiling and reject excess at the `Simplify` entry point with `kTooManyVariables`. 24 caps the sig at ~16M entries (~128 MiB) — comfortably above:

- the 6-8 vars used by the existing test corpus
- the 20-var `kMaxPolyVars` ceiling in `MonomialKey.h`
- the 16-var default `opts.max_vars` policy

## Test plan

- [x] `RejectsExcessiveInputVarCount` — 25 vars (one over the ceiling) returns `kTooManyVariables` without allocating.
- [x] `AcceptsInputVarCountAtCeiling` — exactly 24 vars passes through (`>` boundary check).
- [x] All 1165 existing unit tests still pass (dataset benchmarks excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)