### PR TITLE
fix: reject malformed bitwidth at Simplify and NormalizeToSemilinear entries

### DIFF
--- a/include/cobra/core/DecompositionEngine.h
+++ b/include/cobra/core/DecompositionEngine.h
@@ -65,6 +65,9 @@ namespace cobra {
 
     // Build a remainder evaluator: r(x) = (f(x) - EvalExpr(prefix, x, bw)) & mask.
     // The prefix expression is cloned internally.
+    // Precondition: bitwidth must be in [1, 64]. The orchestrator's
+    // Simplify entry already enforces this; debug builds assert at the
+    // function boundary as defense-in-depth.
     Evaluator
     BuildRemainderEvaluator(const Evaluator &original, const Expr &prefix, uint32_t bitwidth);
 

--- a/include/cobra/core/Result.h
+++ b/include/cobra/core/Result.h
@@ -12,6 +12,7 @@ namespace cobra {
         kTooManyVariables,
         kNoReduction,
         kVerificationFailed,
+        kInvalidArgument,
     };
 
     struct ErrorInfo

--- a/lib/core/DecompositionEngine.cpp
+++ b/lib/core/DecompositionEngine.cpp
@@ -11,6 +11,7 @@
 #include "cobra/core/SignatureEval.h"
 #include "cobra/core/TemplateDecomposer.h"
 #include "cobra/core/Trace.h"
+#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <numeric>
@@ -83,6 +84,14 @@ namespace cobra {
 
     Evaluator
     BuildRemainderEvaluator(const Evaluator &original, const Expr &core, uint32_t bitwidth) {
+        // Mirror Simplify's public-API guard. The orchestrator already
+        // rejects bitwidth ∉ [1, 64] before any decomposition pass runs;
+        // this assert protects callers that bypass Simplify (tests,
+        // direct DecompositionContext construction).
+        assert(
+            bitwidth >= 1 && bitwidth <= 64
+            && "BuildRemainderEvaluator: bitwidth must be in [1, 64]"
+        );
         auto compiled_core   = std::make_shared< CompiledExpr >(CompileExpr(core, bitwidth));
         const uint64_t kMask = Bitmask(bitwidth);
         return Evaluator(

--- a/lib/core/Expr.cpp
+++ b/lib/core/Expr.cpp
@@ -78,6 +78,13 @@ namespace cobra {
         ) {
             switch (expr.kind) {
                 case Expr::Kind::kConstant: {
+                    // bitwidth==0 has no representable sign bit; render as
+                    // plain decimal to avoid UB in `1ULL << (bitwidth - 1)`
+                    // (the uint32 underflow would shift by 0xFFFFFFFF).
+                    if (bitwidth == 0) {
+                        out << expr.constant_val;
+                        break;
+                    }
                     const uint64_t kMask =
                         (bitwidth >= 64) ? UINT64_MAX : (1ULL << bitwidth) - 1;
                     const uint64_t kHalf =

--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -920,6 +920,17 @@ namespace cobra {
             );
         }
 
+        // Reject malformed bitwidth at the public API boundary. bitwidth=0
+        // makes Bitmask(0) return 0, silently masking every evaluator's
+        // output to 0; bitwidth>64 has no meaningful interpretation in a
+        // 64-bit modular ring and triggers shift UB downstream.
+        if (opts.bitwidth == 0 || opts.bitwidth > 64) {
+            return Err< SimplifyOutcome >(
+                CobraError::kInvalidArgument,
+                "bitwidth must be in [1, 64]; got " + std::to_string(opts.bitwidth)
+            );
+        }
+
         // Dynamic masking: if the root is (2^m - 1) & g and g contains
         // no right shifts, try solving g under bitwidth=m. Modular
         // arithmetic for {+, -, *, &, |, ^, ~} is homomorphic, so

--- a/lib/core/SemilinearNormalizer.cpp
+++ b/lib/core/SemilinearNormalizer.cpp
@@ -386,6 +386,16 @@ namespace cobra {
         COBRA_TRACE(
             "Semilinear", "NormalizeToSemilinear: vars={} bitwidth={}", vars.size(), bitwidth
         );
+        // bitwidth=0 makes Bitmask(0) return 0, which would zero every
+        // coefficient and drop every term — the pipeline silently emits
+        // Constant(0) for any input. bitwidth>64 has no meaningful
+        // interpretation in this 64-bit modular ring.
+        if (bitwidth == 0 || bitwidth > 64) {
+            return Err< SemilinearIR >(
+                CobraError::kInvalidArgument,
+                "bitwidth must be in [1, 64]; got " + std::to_string(bitwidth)
+            );
+        }
         CollectCtx ctx; // NOLINT(misc-const-correctness)
         ctx.bitwidth = bitwidth;
         ctx.mask     = Bitmask(bitwidth);

--- a/test/core/test_expr.cpp
+++ b/test/core/test_expr.cpp
@@ -82,6 +82,16 @@ TEST(ExprTest, RenderPositiveConstant8) {
     EXPECT_EQ(Render(*e, {}, 8), "127");
 }
 
+// Regression: expr-foundation-1. RenderImpl's negative-constant
+// detection computed `1ULL << (bitwidth - 1)` unconditionally; on
+// bitwidth=0 the uint32 underflow propagated into a shift count of
+// 0xFFFFFFFF, which is C++ UB. The fix renders bitwidth=0 constants
+// as plain decimal (no representable sign bit).
+TEST(ExprTest, RenderConstantBitwidthZero) {
+    auto e = Expr::Constant(42);
+    EXPECT_EQ(Render(*e, {}, 0), "42");
+}
+
 TEST(ExprTest, LogicalShrConstruction) {
     auto shr = Expr::LogicalShr(Expr::Variable(0), 3);
     EXPECT_EQ(shr->kind, Expr::Kind::kShr);

--- a/test/core/test_result.cpp
+++ b/test/core/test_result.cpp
@@ -23,12 +23,14 @@ TEST(ResultTest, AllErrorCodes) {
     auto toomany = Err< int >(CobraError::kTooManyVariables, "");
     auto noreduc = Err< int >(CobraError::kNoReduction, "");
     auto verify  = Err< int >(CobraError::kVerificationFailed, "");
+    auto invalid = Err< int >(CobraError::kInvalidArgument, "");
 
     EXPECT_EQ(parse.error().code, CobraError::kParseError);
     EXPECT_EQ(nonlin.error().code, CobraError::kNonLinearInput);
     EXPECT_EQ(toomany.error().code, CobraError::kTooManyVariables);
     EXPECT_EQ(noreduc.error().code, CobraError::kNoReduction);
     EXPECT_EQ(verify.error().code, CobraError::kVerificationFailed);
+    EXPECT_EQ(invalid.error().code, CobraError::kInvalidArgument);
 }
 
 TEST(ResultTest, MoveOnlyValue) {

--- a/test/core/test_semilinear_normalizer.cpp
+++ b/test/core/test_semilinear_normalizer.cpp
@@ -1,7 +1,27 @@
+#include "cobra/core/Result.h"
 #include "cobra/core/SemilinearNormalizer.h"
 #include <gtest/gtest.h>
 
 using namespace cobra;
+
+// Regression: semilinear-decomposition-cross-6. NormalizeToSemilinear's
+// public signature accepted any uint32_t bitwidth. With bitwidth=0,
+// Bitmask(0)=0 zeroes every coefficient, every term collapses, and the
+// pipeline silently emits Constant(0) for any input. Reject at the
+// API boundary instead.
+TEST(NormalizerTest, RejectsBitwidthZero) {
+    auto e  = Expr::BitwiseAnd(Expr::Variable(0), Expr::Constant(0xFF));
+    auto ir = NormalizeToSemilinear(*e, { "x" }, 0);
+    ASSERT_FALSE(ir.has_value());
+    EXPECT_EQ(ir.error().code, CobraError::kInvalidArgument);
+}
+
+TEST(NormalizerTest, RejectsBitwidthAbove64) {
+    auto e  = Expr::BitwiseAnd(Expr::Variable(0), Expr::Constant(0xFF));
+    auto ir = NormalizeToSemilinear(*e, { "x" }, 65);
+    ASSERT_FALSE(ir.has_value());
+    EXPECT_EQ(ir.error().code, CobraError::kInvalidArgument);
+}
 
 TEST(NormalizerTest, SingleAtom) {
     auto e  = Expr::BitwiseAnd(Expr::Variable(0), Expr::Constant(0xFF));

--- a/test/core/test_simplifier.cpp
+++ b/test/core/test_simplifier.cpp
@@ -1901,6 +1901,46 @@ TEST(SimplifierTest, RejectsExcessiveInputVarCount) {
     EXPECT_EQ(result.error().code, CobraError::kTooManyVariables);
 }
 
+// Regression: bitwidth-precondition cluster (lifting-passes-cross-4,
+// semilinear-decomposition-cross-6, decomposition-engine-cross-2).
+// Bitmask(0) returns 0, so an unguarded bitwidth=0 silently masks every
+// evaluator's output to 0 and verification against itself passes
+// vacuously — Simplify would return an all-zero "simplified" form for
+// any input. Reject at the public-API boundary instead.
+TEST(SimplifierTest, RejectsBitwidthZero) {
+    std::vector< std::string > vars = { "x" };
+    std::vector< uint64_t > sig     = { 0, 1 };
+    Options opts{ .bitwidth = 0, .max_vars = 16, .spot_check = false };
+
+    auto result = Simplify(sig, vars, nullptr, opts);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, CobraError::kInvalidArgument);
+}
+
+TEST(SimplifierTest, RejectsBitwidthAbove64) {
+    // bitwidth=128 has no representation in the 64-bit modular ring;
+    // shift expressions downstream would be UB.
+    std::vector< std::string > vars = { "x" };
+    std::vector< uint64_t > sig     = { 0, 1 };
+    Options opts{ .bitwidth = 128, .max_vars = 16, .spot_check = false };
+
+    auto result = Simplify(sig, vars, nullptr, opts);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, CobraError::kInvalidArgument);
+}
+
+TEST(SimplifierTest, AcceptsBitwidth1) {
+    // Lower boundary of the valid range; in 1-bit modular arithmetic
+    // every variable is in {0,1} so x+y == x^y.
+    auto expr                       = Expr::Add(Expr::Variable(0), Expr::Variable(1));
+    std::vector< std::string > vars = { "x", "y" };
+    auto sig                        = EvaluateBooleanSignature(*expr, 2, 1);
+    Options opts{ .bitwidth = 1, .max_vars = 16, .spot_check = false };
+
+    auto result = Simplify(sig, vars, expr.get(), opts);
+    ASSERT_TRUE(result.has_value());
+}
+
 TEST(SimplifierTest, AcceptsInputVarCountAtCeiling) {
     // Exactly kMaxInputVars=24. The pre-check is `>` so this must
     // pass through to the normal pipeline. Constant sig of correct


### PR DESCRIPTION
## Summary

Closes the **bitwidth-precondition** cluster (4 findings) from the 2026-05-04 audit. `Bitmask(0)` returns 0, so an unguarded `bitwidth=0` silently masks every evaluator's output to 0 and verification against itself passes vacuously — `Simplify` would return an all-zero "simplified" form for any input. `bitwidth>64` has no representation in the 64-bit modular ring and triggers shift UB downstream.

Findings closed:
- `expr-foundation-1` — RenderImpl bitwidth=0 sign-bit shift UB
- `lifting-passes-cross-4` — bitwidth=0 silently masks every evaluator's output to 0
- `semilinear-decomposition-cross-6` — NormalizeToSemilinear silently emits Constant(0) for bitwidth=0
- `decomposition-engine-cross-2` — BuildRemainderEvaluator/AcceptCore accept bitwidth out of [2, 64]

## Changes

- New `CobraError::kInvalidArgument` variant.
- `Simplify` and `NormalizeToSemilinear` reject `bitwidth ∉ [1, 64]` at the public-API boundary.
- `BuildRemainderEvaluator` debug-asserts `bitwidth ∈ [1, 64]` and documents the precondition in its header.
- `RenderImpl` renders `bitwidth=0` constants as plain decimal (no representable sign bit) to close the underflow shift UB.

## Test plan

- [x] 7 new regression tests across `test_simplifier`, `test_semilinear_normalizer`, `test_expr`, `test_result`
- [x] Full unit suite (1177 tests, dataset/diagnostic suites excluded) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)