### PR TITLE
fix: bound-check var_index reads across evaluators and remappers

### DIFF
--- a/lib/core/AuxVarEliminator.cpp
+++ b/lib/core/AuxVarEliminator.cpp
@@ -3,10 +3,12 @@
 #include "cobra/core/Trace.h"
 #include <algorithm>
 #include <bit>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -225,6 +227,16 @@ namespace cobra {
 
         // Re-check each spurious variable at full width
         const auto kNumVars = static_cast< uint32_t >(vars.size());
+        // var_idx maps each variable name back to its original index. If
+        // `vars` contains duplicate names, the second insertion overwrites
+        // the first and `var_idx.at(sv)` returns the wrong index — the
+        // IsSpuriousFullWidth probe targets the wrong variable. The Simplify
+        // public-API caller deduplicates, but tests and direct callers may
+        // not; assert at the boundary to fail loud on misuse.
+        assert(
+            (std::unordered_set< std::string >(vars.begin(), vars.end()).size() == vars.size())
+            && "EliminateAuxVars: vars must contain unique names"
+        );
         std::unordered_map< std::string, uint32_t > var_idx;
         for (uint32_t j = 0; j < kNumVars; ++j) { var_idx[vars[j]] = j; }
 

--- a/lib/core/BitwiseDecomposer.cpp
+++ b/lib/core/BitwiseDecomposer.cpp
@@ -3,6 +3,7 @@
 #include "cobra/core/Profile.h"
 #include "cobra/core/SignatureSimplifier.h"
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -21,6 +22,15 @@ namespace cobra {
             case Expr::Kind::kConstant:
                 return Expr::Constant(expr.constant_val);
             case Expr::Kind::kVariable:
+                // Caller (ExtractTemplateCore, RunResidualTemplate) sizes
+                // index_map to cover the template-generated expression's
+                // variable space. A var_index past index_map's end means
+                // the caller passed a mismatched map — debug-assert at the
+                // boundary; the read is otherwise unchecked.
+                assert(
+                    expr.var_index < index_map.size()
+                    && "RemapVars: var_index out of range for index_map"
+                );
                 return Expr::Variable(index_map[expr.var_index]);
             case Expr::Kind::kAdd:
                 return Expr::Add(

--- a/lib/core/LiftingPasses.cpp
+++ b/lib/core/LiftingPasses.cpp
@@ -7,7 +7,9 @@
 #include "cobra/core/SignatureEval.h"
 
 #include <algorithm>
+#include <cassert>
 #include <functional>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -172,7 +174,7 @@ namespace cobra {
             return result;
         }
 
-        uint32_t FindVirtualIndex(
+        std::optional< uint32_t > FindVirtualIndex(
             const Expr &node, const std::vector< DeduplicatedAtom > &atoms,
             const std::vector< std::string > &vars, uint32_t bitwidth
         ) {
@@ -181,7 +183,7 @@ namespace cobra {
             for (const auto &atom : atoms) {
                 if (atom.hash == h && atom.rendered == rendered) { return atom.virtual_index; }
             }
-            return UINT32_MAX;
+            return std::nullopt;
         }
 
         std::unique_ptr< Expr > ReplaceAtomsWithVirtual(
@@ -192,8 +194,14 @@ namespace cobra {
             if (parent_is_bitwise && IsPureArithmetic(node) && HasVarDep(node)
                 && node.kind != Expr::Kind::kVariable)
             {
-                uint32_t vi = FindVirtualIndex(node, atoms, vars, bitwidth);
-                return Expr::Variable(vi);
+                // CollectLiftableAtoms walks the same predicate before
+                // ReplaceAtomsWithVirtual runs, so every node reaching
+                // this branch must already be in `atoms`. Assert the
+                // invariant rather than producing Variable(UINT32_MAX)
+                // on a sentinel miss.
+                auto vi = FindVirtualIndex(node, atoms, vars, bitwidth);
+                assert(vi.has_value() && "ReplaceAtomsWithVirtual: liftable atom missing from atom table");
+                return Expr::Variable(*vi);
             }
 
             auto result          = std::make_unique< Expr >();

--- a/lib/core/LiftingPasses.cpp
+++ b/lib/core/LiftingPasses.cpp
@@ -200,7 +200,10 @@ namespace cobra {
                 // invariant rather than producing Variable(UINT32_MAX)
                 // on a sentinel miss.
                 auto vi = FindVirtualIndex(node, atoms, vars, bitwidth);
-                assert(vi.has_value() && "ReplaceAtomsWithVirtual: liftable atom missing from atom table");
+                assert(
+                    vi.has_value()
+                    && "ReplaceAtomsWithVirtual: liftable atom missing from atom table"
+                );
                 return Expr::Variable(*vi);
             }
 

--- a/lib/core/SemilinearSignature.cpp
+++ b/lib/core/SemilinearSignature.cpp
@@ -130,9 +130,8 @@ namespace cobra {
                     // sub-expression with var_index >= num_vars indicates a
                     // malformed AST. Return 0 (treat the variable as having
                     // no contribution) instead of an OOB read.
-                    return (expr.var_index < var_vals.size())
-                        ? var_vals[expr.var_index] & mask
-                        : 0;
+                    return (expr.var_index < var_vals.size()) ? var_vals[expr.var_index] & mask
+                                                              : 0;
                 case Expr::Kind::kNot:
                     return (~EvalAtPoint(*expr.children[0], var_vals, mask)) & mask;
                 case Expr::Kind::kNeg:

--- a/lib/core/SemilinearSignature.cpp
+++ b/lib/core/SemilinearSignature.cpp
@@ -126,7 +126,13 @@ namespace cobra {
                 case Expr::Kind::kConstant:
                     return expr.constant_val & mask;
                 case Expr::Kind::kVariable:
-                    return var_vals[expr.var_index] & mask;
+                    // var_vals is sized to num_vars by IsLinearShortcut; a
+                    // sub-expression with var_index >= num_vars indicates a
+                    // malformed AST. Return 0 (treat the variable as having
+                    // no contribution) instead of an OOB read.
+                    return (expr.var_index < var_vals.size())
+                        ? var_vals[expr.var_index] & mask
+                        : 0;
                 case Expr::Kind::kNot:
                     return (~EvalAtPoint(*expr.children[0], var_vals, mask)) & mask;
                 case Expr::Kind::kNeg:

--- a/test/core/test_semilinear_signature.cpp
+++ b/test/core/test_semilinear_signature.cpp
@@ -109,3 +109,18 @@ TEST(SemilinearSignatureTest, LinearShortcutFalseForSemilinear) {
         Expr::Mul(Expr::Constant(3), Expr::BitwiseAnd(Expr::Variable(0), Expr::Constant(0x0F)));
     EXPECT_FALSE(IsLinearShortcut(*e, 1, 8));
 }
+
+// Regression: semilinear-decomposition-7. EvalAtPoint indexed
+// var_vals[expr.var_index] without checking var_index < var_vals.size().
+// A malformed AST with Variable indices past num_vars triggered an
+// out-of-bounds vector read. The fix returns 0 for out-of-range
+// indices so the evaluator is robust against caller mistakes.
+TEST(SemilinearSignatureTest, OutOfRangeVarIndexHandledByLinearShortcut) {
+    // Build "Variable(5) + Variable(0)" but tell IsLinearShortcut that
+    // num_vars=1. Variable(5) is OOB; EvalAtPoint must not read past the
+    // 1-element assignment buffer. The resulting expression is constant-
+    // ish from the evaluator's view (Variable(5) always returns 0), so
+    // it should still be classified as linear.
+    auto expr = Expr::Add(Expr::Variable(5), Expr::Variable(0));
+    EXPECT_TRUE(IsLinearShortcut(*expr, 1, 8));
+}


### PR DESCRIPTION
## Summary

Closes the **var-index-bounds** cluster (4 findings) from the 2026-05-04 audit. Several Expr-walking sites read `var_vals[expr.var_index]`, `index_map[var_index]`, or `var_idx[name]` without verifying the index is in range, returned a sentinel `UINT32_MAX` on lookup miss, or trusted that variable names are unique. Each is reachable from a malformed-AST or duplicated-name caller.

Findings closed:
- `semilinear-decomposition-7` — EvalAtPoint var_index OOB read on malformed AST
- `decomposition-engine-6` — RemapVars OOB on undersized index_map
- `lifting-passes-7` — FindVirtualIndex returns UINT32_MAX sentinel; caller doesn't check
- `expr-foundation-2` — EliminateAuxVars duplicate variable names corrupt var_idx mapping

## Changes

- `EvalAtPoint` returns 0 for out-of-range Variable indices instead of reading past the assignment buffer.
- `RemapVars` debug-asserts the `index_map` size precondition.
- `FindVirtualIndex` returns `std::optional<uint32_t>` instead of `UINT32_MAX`. Its single caller `ReplaceAtomsWithVirtual` asserts the lookup succeeds — `CollectLiftableAtoms` walks the same predicate beforehand, so every reachable node must already be present in `atoms`.
- `EliminateAuxVars` (full-width overload) debug-asserts `vars` are unique before building the `var_idx` map.

## Test plan

- [x] `SemilinearSignatureTest.OutOfRangeVarIndexHandledByLinearShortcut` regression
- [x] Full unit suite (1172 tests, dataset/diagnostic suites excluded) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)