### PR TITLE
fix: prune dead PassOutcome variants and harden contract enforcement

### DIFF
--- a/include/cobra/core/PassContract.h
+++ b/include/cobra/core/PassContract.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "cobra/core/Classification.h"
 #include "cobra/core/Expr.h"
 
 #include <cassert>
@@ -163,12 +162,14 @@ namespace cobra {
         kRejected,
     };
 
-    struct PendingWork
-    {
-        std::unique_ptr< Expr > residual;
-        Classification residual_classification;
-    };
-
+    // PassOutcome currently uses only kSuccess and kBlocked from OutcomeKind.
+    // The kInapplicable/kPartial/kVerifyFailed variants of OutcomeKind are
+    // produced exclusively by SolverResult — PassOutcome's named constructors
+    // for those variants were declared but never called in production code.
+    // They were removed; if a future pass needs partial-residual or
+    // verify-failed semantics, add a fresh deliberate PassOutcome variant
+    // with a dedicated consumer branch in ToSimplifyOutcome rather than
+    // repurposing the SolverResult enum tags.
     class [[nodiscard]] PassOutcome
     {
       public:
@@ -179,18 +180,7 @@ namespace cobra {
             VerificationState verification
         );
 
-        static PassOutcome Inapplicable(ReasonDetail reason);
         static PassOutcome Blocked(ReasonDetail reason);
-
-        static PassOutcome Partial(
-            std::unique_ptr< Expr > expr, std::vector< std::string > real_vars,
-            VerificationState verification, PendingWork pending, ReasonDetail reason
-        );
-
-        static PassOutcome VerifyFailed(
-            std::unique_ptr< Expr > expr, std::vector< std::string > real_vars,
-            ReasonDetail reason
-        );
 
         OutcomeKind Kind() const { return kind_; }
 
@@ -203,7 +193,6 @@ namespace cobra {
         VerificationState Verification() const;
 
         const ReasonDetail &Reason() const;
-        const PendingWork &Pending() const;
 
         const std::vector< uint64_t > &SigVector() const;
         void SetSigVector(std::vector< uint64_t > sv);
@@ -219,7 +208,6 @@ namespace cobra {
         std::vector< std::string > real_vars_;
         VerificationState verification_ = VerificationState::kUnverified;
         std::optional< ReasonDetail > reason_;
-        std::optional< PendingWork > pending_;
         std::vector< uint64_t > sig_vector_;
         std::optional< DecompositionMeta > decomposition_meta_;
     };

--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -855,8 +855,9 @@ namespace cobra {
                 // forgets the metadata field would otherwise see its
                 // verified rewrite reported as unverified. PassOutcome is
                 // the authoritative source for the success branch.
-                outcome.verified = result.outcome.Verification() == VerificationState::kVerified;
-                outcome.expr      = CleanupFinalExpr(result.outcome.TakeExpr(), bitwidth);
+                outcome.verified =
+                    result.outcome.Verification() == VerificationState::kVerified;
+                outcome.expr       = CleanupFinalExpr(result.outcome.TakeExpr(), bitwidth);
                 outcome.sig_vector = std::move(result.metadata.sig_vector);
             } else {
                 outcome.kind = SimplifyOutcome::Kind::kUnchangedUnsupported;

--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -847,9 +847,16 @@ namespace cobra {
 
             if (result.outcome.Succeeded()) {
                 outcome.kind      = SimplifyOutcome::Kind::kSimplified;
-                outcome.expr      = CleanupFinalExpr(result.outcome.TakeExpr(), bitwidth);
                 outcome.real_vars = result.outcome.RealVars();
-                outcome.verified = result.metadata.verification == VerificationState::kVerified;
+                // Read PassOutcome.Verification() instead of the parallel
+                // ItemMetadata.verification field. The two were initialized
+                // from the same source at every call site by convention; a
+                // future producer that stamps PassOutcome correctly but
+                // forgets the metadata field would otherwise see its
+                // verified rewrite reported as unverified. PassOutcome is
+                // the authoritative source for the success branch.
+                outcome.verified = result.outcome.Verification() == VerificationState::kVerified;
+                outcome.expr      = CleanupFinalExpr(result.outcome.TakeExpr(), bitwidth);
                 outcome.sig_vector = std::move(result.metadata.sig_vector);
             } else {
                 outcome.kind = SimplifyOutcome::Kind::kUnchangedUnsupported;

--- a/lib/core/PassContract.cpp
+++ b/lib/core/PassContract.cpp
@@ -1,9 +1,18 @@
 #include "cobra/core/PassContract.h"
 
-#include <cassert>
+#include <cstdlib>
 #include <utility>
 
 namespace cobra {
+
+    namespace {
+        // Replaces assert() with a release-build runtime check. assert() is
+        // compiled out under -DNDEBUG, so a violation in release would
+        // dereference an empty optional / null unique_ptr → UB. std::abort
+        // matches the death-test contract while failing loud in either
+        // build mode.
+        [[noreturn]] void ContractAbort() { std::abort(); }
+    } // namespace
 
     PassOutcome::PassOutcome(OutcomeKind kind) : kind_(kind) {}
 
@@ -18,82 +27,35 @@ namespace cobra {
         return o;
     }
 
-    PassOutcome PassOutcome::Inapplicable(ReasonDetail reason) {
-        PassOutcome o(OutcomeKind::kInapplicable);
-        o.reason_.emplace(std::move(reason));
-        return o;
-    }
-
     PassOutcome PassOutcome::Blocked(ReasonDetail reason) {
         PassOutcome o(OutcomeKind::kBlocked);
         o.reason_.emplace(std::move(reason));
         return o;
     }
 
-    PassOutcome PassOutcome::Partial(
-        std::unique_ptr< Expr > expr, std::vector< std::string > real_vars,
-        VerificationState verification, PendingWork pending, ReasonDetail reason
-    ) {
-        PassOutcome o(OutcomeKind::kPartial);
-        o.expr_         = std::move(expr);
-        o.real_vars_    = std::move(real_vars);
-        o.verification_ = verification;
-        o.pending_.emplace(std::move(pending));
-        o.reason_.emplace(std::move(reason));
-        return o;
-    }
-
-    PassOutcome PassOutcome::VerifyFailed(
-        std::unique_ptr< Expr > expr, std::vector< std::string > real_vars, ReasonDetail reason
-    ) {
-        PassOutcome o(OutcomeKind::kVerifyFailed);
-        o.expr_         = std::move(expr);
-        o.real_vars_    = std::move(real_vars);
-        o.verification_ = VerificationState::kRejected;
-        o.reason_.emplace(std::move(reason));
-        return o;
-    }
-
     const Expr &PassOutcome::GetExpr() const {
-        assert(
-            kind_ == OutcomeKind::kSuccess || kind_ == OutcomeKind::kPartial
-            || kind_ == OutcomeKind::kVerifyFailed
-        );
+        if (kind_ != OutcomeKind::kSuccess) { ContractAbort(); }
         return *expr_;
     }
 
     std::unique_ptr< Expr > PassOutcome::TakeExpr() {
-        assert(
-            kind_ == OutcomeKind::kSuccess || kind_ == OutcomeKind::kPartial
-            || kind_ == OutcomeKind::kVerifyFailed
-        );
+        if (kind_ != OutcomeKind::kSuccess) { ContractAbort(); }
         return std::move(expr_);
     }
 
     const std::vector< std::string > &PassOutcome::RealVars() const {
-        assert(
-            kind_ == OutcomeKind::kSuccess || kind_ == OutcomeKind::kPartial
-            || kind_ == OutcomeKind::kVerifyFailed
-        );
+        if (kind_ != OutcomeKind::kSuccess) { ContractAbort(); }
         return real_vars_;
     }
 
     VerificationState PassOutcome::Verification() const {
-        assert(
-            kind_ == OutcomeKind::kSuccess || kind_ == OutcomeKind::kPartial
-            || kind_ == OutcomeKind::kVerifyFailed
-        );
+        if (kind_ != OutcomeKind::kSuccess) { ContractAbort(); }
         return verification_;
     }
 
     const ReasonDetail &PassOutcome::Reason() const {
-        assert(kind_ != OutcomeKind::kSuccess);
+        if (kind_ == OutcomeKind::kSuccess) { ContractAbort(); }
         return *reason_;
-    }
-
-    const PendingWork &PassOutcome::Pending() const {
-        assert(kind_ == OutcomeKind::kPartial);
-        return *pending_;
     }
 
     const std::vector< uint64_t > &PassOutcome::SigVector() const { return sig_vector_; }

--- a/test/core/test_pass_contract.cpp
+++ b/test/core/test_pass_contract.cpp
@@ -107,13 +107,13 @@ TEST(PassOutcomeTest, SuccessCarriesExprAndVars) {
     EXPECT_EQ(o.GetExpr().constant_val, 42);
 }
 
-TEST(PassOutcomeTest, InapplicableHasNoExpr) {
-    ReasonDetail reason{ .top = { .code = { .category = ReasonCategory::kGuardFailed,
+TEST(PassOutcomeTest, BlockedHasReasonNoExpr) {
+    ReasonDetail reason{ .top = { .code = { .category = ReasonCategory::kRepresentationGap,
                                             .domain   = ReasonDomain::kSemilinear } } };
-    auto o = PassOutcome::Inapplicable(std::move(reason));
+    auto o = PassOutcome::Blocked(std::move(reason));
     EXPECT_FALSE(o.Succeeded());
-    EXPECT_EQ(o.Kind(), OutcomeKind::kInapplicable);
-    EXPECT_EQ(o.Reason().top.code.category, ReasonCategory::kGuardFailed);
+    EXPECT_EQ(o.Kind(), OutcomeKind::kBlocked);
+    EXPECT_EQ(o.Reason().top.code.category, ReasonCategory::kRepresentationGap);
 }
 
 TEST(PassOutcomeTest, SigVectorThreadsThrough) {
@@ -126,48 +126,18 @@ TEST(PassOutcomeTest, SigVectorThreadsThrough) {
     EXPECT_EQ(o.SigVector()[3], 4);
 }
 
-TEST(PassOutcomeTest, PartialCarriesExprAndPending) {
-    auto residual = Expr::Variable(0);
-    Classification residual_cls{ .semantic = SemanticClass::kLinear, .flags = kSfNone };
-    PendingWork pw{ .residual = std::move(residual), .residual_classification = residual_cls };
-    ReasonDetail reason{
-        .top = { .code    = { .category = ReasonCategory::kRepresentationGap,
-                              .domain   = ReasonDomain::kDecomposition },
-                .message = "partial decomposition" }
-    };
-    auto o = PassOutcome::Partial(
-        Expr::Constant(7), { "x" }, VerificationState::kUnverified, std::move(pw),
-        std::move(reason)
-    );
-    EXPECT_FALSE(o.Succeeded());
-    EXPECT_EQ(o.Kind(), OutcomeKind::kPartial);
-    EXPECT_EQ(o.GetExpr().constant_val, 7);
-    EXPECT_EQ(o.RealVars().size(), 1);
-    EXPECT_EQ(o.Verification(), VerificationState::kUnverified);
-    EXPECT_EQ(o.Pending().residual->kind, Expr::Kind::kVariable);
-    EXPECT_EQ(o.Reason().top.code.category, ReasonCategory::kRepresentationGap);
-}
+// --- PassOutcome contract violations now abort in both debug and
+// release builds (no more #ifdef NDEBUG skip). The accessors check
+// kind_ at runtime via std::abort(), matching SolverResult's design.
 
-// --- PassOutcome death tests (assert-guarded, debug builds only) ---
-
-#ifdef NDEBUG
-TEST(PassOutcomeDeathTest, ExprOnBlockedAsserts) {
-    GTEST_SKIP() << "assert() compiled out in Release builds";
-}
-
-TEST(PassOutcomeDeathTest, PendingOnNonPartialAsserts) {
-    GTEST_SKIP() << "assert() compiled out in Release builds";
-}
-#else
-TEST(PassOutcomeDeathTest, ExprOnBlockedAsserts) {
+TEST(PassOutcomeDeathTest, ExprOnBlockedAborts) {
     ReasonDetail reason{ .top = { .code = { .category = ReasonCategory::kRepresentationGap,
                                             .domain   = ReasonDomain::kSemilinear } } };
     auto o = PassOutcome::Blocked(std::move(reason));
     EXPECT_DEATH(o.GetExpr(), "");
 }
 
-TEST(PassOutcomeDeathTest, PendingOnNonPartialAsserts) {
+TEST(PassOutcomeDeathTest, ReasonOnSuccessAborts) {
     auto o = PassOutcome::Success(Expr::Constant(0), {}, VerificationState::kVerified);
-    EXPECT_DEATH(o.Pending(), "");
+    EXPECT_DEATH(o.Reason(), "");
 }
-#endif


### PR DESCRIPTION
## Summary

Closes the **pass-outcome-contract** cluster (3 findings) from the 2026-05-04 audit. PassOutcome declared 5 `OutcomeKind` variants but production code only ever constructed `kSuccess` and `kBlocked` — the others were dead public API exercised only by tests. `ToSimplifyOutcome` also read `ItemMetadata.verification` instead of `PassOutcome.Verification()`, maintaining two parallel verification fields kept in lockstep only by convention. PassOutcome accessors guarded preconditions with `assert()`, which compiled out under `-DNDEBUG`, leaving release builds with silent UB on contract violation.

Findings closed:
- `orchestrator-core-cross-4` — PassOutcome::Inapplicable/Partial/VerifyFailed declared but never produced; ToSimplifyOutcome lacked branches
- `orchestrator-core-cross-5` — ToSimplifyOutcome read ItemMetadata.verification instead of PassOutcome.Verification (drift-prone)
- `orchestrator-core-6` — PassOutcome accessors enforced kind only via debug assert (release-build UB)

## Changes

- Removed the dead `PassOutcome::Inapplicable` / `Partial` / `VerifyFailed` named constructors, the `PendingWork` struct, and the `Pending()` accessor. `SolverResult` continues to use the `kInapplicable` / `kPartial` / `kVerifyFailed` enum tags for its own outcome variants.
- `ToSimplifyOutcome` reads `PassOutcome.Verification()` in the success branch, eliminating the dual-field drift surface.
- `PassOutcome` accessors use `std::abort()` on contract violation instead of `assert()`, so release builds fail loud. The death tests no longer need `#ifdef NDEBUG` skips.
- Net diff: -73 lines (`-116 / +43`).

## Test plan

- [x] `PassOutcomeDeathTest.ExprOnBlockedAborts` and `PassOutcomeDeathTest.ReasonOnSuccessAborts` regression tests run unconditionally and pass
- [x] All 13 PassContract tests pass
- [x] Full unit suite (1170 tests, dataset/diagnostic suites excluded) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)