### PR TITLE
fix: route Expr field copies through CloneExpr in lifting rewrites

### DIFF
--- a/lib/core/CompiledExpr.cpp
+++ b/lib/core/CompiledExpr.cpp
@@ -8,6 +8,13 @@
 
 namespace cobra {
 
+    // EvalInstr captures only `kind` and a single `operand` derived from
+    // `constant_val` or `var_index` — it is intentionally narrower than
+    // Expr. CompileExpr therefore cannot reuse CloneExpr's field-copy
+    // pattern. Adding a new field to Expr (see lib/core/Expr.cpp's
+    // CloneExpr) requires explicit consideration of compiled-program
+    // semantics here: pick a representation, extend EvalInstr, or
+    // declare the new field unmaterialized.
     CompiledExpr CompileExpr(const Expr &expr, uint32_t bitwidth) {
         struct CompileFrame
         {

--- a/lib/core/LiftingPasses.cpp
+++ b/lib/core/LiftingPasses.cpp
@@ -88,13 +88,21 @@ namespace cobra {
             std::string rendered;
         };
 
+        // Single source of truth for the lift predicate, shared by
+        // CollectLiftableAtoms and ReplaceAtomsWithVirtual. Drift between
+        // the two sites would silently corrupt the rewrite (collected
+        // atoms not replaced, or non-collected nodes replaced with
+        // virtual variables).
+        bool ShouldLift(const Expr &node, bool parent_is_bitwise) {
+            return parent_is_bitwise && IsPureArithmetic(node) && HasVarDep(node)
+                && node.kind != Expr::Kind::kVariable;
+        }
+
         void CollectLiftableAtoms(
             const Expr &node, bool parent_is_bitwise, const std::vector< std::string > &vars,
             uint32_t bitwidth, std::vector< LiftCandidate > &out
         ) {
-            if (parent_is_bitwise && IsPureArithmetic(node) && HasVarDep(node)
-                && node.kind != Expr::Kind::kVariable)
-            {
+            if (ShouldLift(node, parent_is_bitwise)) {
                 size_t h      = std::hash< Expr >{}(node);
                 auto rendered = Render(node, vars, bitwidth);
                 out.push_back(
@@ -189,17 +197,16 @@ namespace cobra {
             const std::vector< DeduplicatedAtom > &atoms,
             const std::vector< std::string > &vars, uint32_t bitwidth
         ) {
-            if (parent_is_bitwise && IsPureArithmetic(node) && HasVarDep(node)
-                && node.kind != Expr::Kind::kVariable)
-            {
+            if (ShouldLift(node, parent_is_bitwise)) {
                 uint32_t vi = FindVirtualIndex(node, atoms, vars, bitwidth);
                 return Expr::Variable(vi);
             }
 
-            auto result          = std::make_unique< Expr >();
-            result->kind         = node.kind;
-            result->constant_val = node.constant_val;
-            result->var_index    = node.var_index;
+            // Clone via CloneExpr (single source of truth for Expr field
+            // copying) and rebuild children with remapped subtrees. A future
+            // Expr field added to CloneExpr propagates here automatically.
+            auto result = CloneExpr(node);
+            result->children.clear();
 
             bool current_is_bitwise = IsBitwiseKind(node.kind);
             for (const auto &child : node.children) {
@@ -310,10 +317,12 @@ namespace cobra {
                 }
             }
 
-            auto result          = std::make_unique< Expr >();
-            result->kind         = node.kind;
-            result->constant_val = node.constant_val;
-            result->var_index    = node.var_index;
+            // Clone via CloneExpr (single source of truth for Expr field
+            // copying) and rebuild children with remapped subtrees. A
+            // future Expr field added to CloneExpr propagates here
+            // automatically.
+            auto result = CloneExpr(node);
+            result->children.clear();
 
             for (const auto &child : node.children) {
                 result->children.push_back(


### PR DESCRIPTION
## Summary

Closes the **manual-node-copy** cluster (3 findings) from the 2026-05-04 audit. `ReplaceAtomsWithVirtual` and `ReplaceRepeatsWithVirtual` built result `Expr` nodes by copying `kind` / `constant_val` / `var_index` manually. Adding any new `Expr` field would silently drift across both sites, leaving rewritten nodes missing the field. The lifting predicate (`parent_is_bitwise && IsPureArithmetic && HasVarDep && kind != kVariable`) was also duplicated between `CollectLiftableAtoms` and `ReplaceAtomsWithVirtual`.

Findings closed:
- `lifting-passes-8` — ReplaceAtomsWithVirtual manual copy + duplicated lifting predicate
- `lifting-passes-13` — ReplaceRepeatsWithVirtual manual copy
- `lifting-passes-cross-7` — three sites with shared field-set assumption

## Changes

- Both rewrite functions now clone via `auto result = CloneExpr(node); result->children.clear();` and rebuild children with remapped subtrees, making `CloneExpr` the single source of truth for `Expr` field copying.
- The lifting predicate is extracted into a `ShouldLift(node, parent_is_bitwise)` helper used by both `CollectLiftableAtoms` and `ReplaceAtomsWithVirtual`.
- `CompileExpr` cannot reuse `CloneExpr` — its `EvalInstr` representation is intentionally narrower than `Expr` — so it gets a header comment marker calling out the discipline required when extending `Expr`.

## Test plan

- [x] All 6 ArithmeticAtomLifter tests pass
- [x] Full unit suite (1171 tests, dataset/diagnostic suites excluded) passes — refactor exercised end-to-end by existing SiMBA / QSynth dataset suites and the lifter unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)