### PR TITLE
fix: unify residual-support cap as kMaxResidualSupport=6

### DIFF
--- a/include/cobra/core/GhostResidualSolver.h
+++ b/include/cobra/core/GhostResidualSolver.h
@@ -9,6 +9,14 @@
 
 namespace cobra {
 
+    // Maximum support size for residual-family solvers (ghost basis,
+    // factored ghost, residual polynomial recovery, ExtractPolyCore).
+    // Sets the array sizes inside SolveGhostResidual (combo, args,
+    // var_indices, ProbePoint::values) AND the runtime cap enforced
+    // by every residual pass / IsBooleanNullResidual. Changing this
+    // constant requires audit of every site that previously hardcoded 6.
+    inline constexpr uint32_t kMaxResidualSupport = 6;
+
     struct GhostSolveResult
     {
         std::unique_ptr< Expr > expr;
@@ -28,7 +36,7 @@ namespace cobra {
 
     // Attempts to solve a boolean-null residual as a constant-coefficient
     // single ghost primitive. Returns expression in original variable space.
-    // Requires support.size() <= 6.
+    // Requires support.size() <= kMaxResidualSupport.
     SolverResult< GhostSolveResult > SolveGhostResidual(
         const Evaluator &residual_eval, const std::vector< uint32_t > &support,
         uint32_t num_vars, uint32_t bitwidth
@@ -38,7 +46,7 @@ namespace cobra {
     // where q is a constant polynomial and g is a ghost primitive.
     // Uses RecoverWeightedPoly with max_degree=0, grid_degree=2.
     // Enumerates ghost primitives in priority order (mul_sub_and first).
-    // Requires support.size() <= 6.
+    // Requires support.size() <= kMaxResidualSupport.
     SolverResult< GhostSolveResult > SolveFactoredGhostResidual(
         const Evaluator &residual_eval, const std::vector< uint32_t > &support,
         uint32_t num_vars, uint32_t bitwidth, uint8_t max_degree = 0, uint8_t grid_degree = 2

--- a/lib/core/DecompositionEngine.cpp
+++ b/lib/core/DecompositionEngine.cpp
@@ -3,6 +3,7 @@
 #include "cobra/core/AuxVarEliminator.h"
 #include "cobra/core/BitWidth.h"
 #include "cobra/core/ExprUtils.h"
+#include "cobra/core/GhostResidualSolver.h"
 #include "cobra/core/MultivarPolyRecovery.h"
 #include "cobra/core/PassContract.h"
 #include "cobra/core/PolyExprBuilder.h"
@@ -202,7 +203,7 @@ namespace cobra {
         auto fw_elim          = EliminateAuxVars(ctx.sig, ctx.vars, ctx.opts.evaluator, kBw);
         const auto kRealCount = static_cast< uint32_t >(fw_elim.real_vars.size());
 
-        if (kRealCount > 6) {
+        if (kRealCount > kMaxResidualSupport) {
             return SolverResult< CoreCandidate >::Inapplicable(
                 ReasonDetail{
                     .top = { .code    = { ReasonCategory::kGuardFailed,

--- a/lib/core/DecompositionPasses.cpp
+++ b/lib/core/DecompositionPasses.cpp
@@ -466,7 +466,7 @@ namespace cobra {
         }
         const auto res_real_count =
             static_cast< uint32_t >(residual.remainder_elim.real_vars.size());
-        if (res_real_count > 6) {
+        if (res_real_count > kMaxResidualSupport) {
             return Ok(
                 PassResult{
                     .decision    = PassDecision::kNotApplicable,
@@ -525,7 +525,7 @@ namespace cobra {
         }
         const auto res_real_count =
             static_cast< uint32_t >(residual.remainder_elim.real_vars.size());
-        if (res_real_count > 6) {
+        if (res_real_count > kMaxResidualSupport) {
             return Ok(
                 PassResult{
                     .decision    = PassDecision::kNotApplicable,
@@ -584,7 +584,7 @@ namespace cobra {
         }
         const auto res_real_count =
             static_cast< uint32_t >(residual.remainder_elim.real_vars.size());
-        if (res_real_count > 6) {
+        if (res_real_count > kMaxResidualSupport) {
             return Ok(
                 PassResult{
                     .decision    = PassDecision::kNotApplicable,
@@ -642,7 +642,7 @@ namespace cobra {
         const auto &residual = std::get< RemainderStatePayload >(item.payload);
         const auto res_real_count =
             static_cast< uint32_t >(residual.remainder_elim.real_vars.size());
-        if (res_real_count > 6) {
+        if (res_real_count > kMaxResidualSupport) {
             return Ok(PassResult{ .decision = PassDecision::kNotApplicable });
         }
 

--- a/lib/core/GhostBasis.cpp
+++ b/lib/core/GhostBasis.cpp
@@ -1,17 +1,35 @@
 #include "cobra/core/GhostBasis.h"
 #include "cobra/core/BitWidth.h"
+#include "cobra/core/GhostResidualSolver.h"
+#include <cassert>
 
 namespace cobra {
 
     namespace {
 
+        // Each eval/build pair takes a span sized exactly `arity`.
+        // Asserting at entry pins the producer/consumer contract: a
+        // future caller that passes a too-small span fails loud instead
+        // of reading past the underlying buffer.
+        constexpr uint8_t kMulSubAndArity   = 2;
+        constexpr uint8_t kMul3SubAnd3Arity = 3;
+
+        static_assert(
+            kMulSubAndArity <= kMaxResidualSupport
+            && kMul3SubAnd3Arity <= kMaxResidualSupport,
+            "Ghost primitive arity exceeds kMaxResidualSupport — "
+            "consumer buffers (combo, args, var_indices) would overflow"
+        );
+
         // mul_sub_and: x*y - (x&y)
         uint64_t EvalMulSubAnd(std::span< const uint64_t > args, uint32_t bw) {
+            assert(args.size() == kMulSubAndArity);
             const uint64_t kMask = Bitmask(bw);
             return ((args[0] * args[1]) - (args[0] & args[1])) & kMask;
         }
 
         std::unique_ptr< Expr > BuildMulSubAnd(std::span< const uint32_t > vars) {
+            assert(vars.size() == kMulSubAndArity);
             return Expr::Add(
                 Expr::Mul(Expr::Variable(vars[0]), Expr::Variable(vars[1])),
                 Expr::Negate(Expr::BitwiseAnd(Expr::Variable(vars[0]), Expr::Variable(vars[1])))
@@ -20,11 +38,13 @@ namespace cobra {
 
         // mul3_sub_and3: x*y*z - (x&y&z)
         uint64_t EvalMul3SubAnd3(std::span< const uint64_t > args, uint32_t bw) {
+            assert(args.size() == kMul3SubAnd3Arity);
             const uint64_t kMask = Bitmask(bw);
             return ((args[0] * args[1] * args[2]) - (args[0] & args[1] & args[2])) & kMask;
         }
 
         std::unique_ptr< Expr > BuildMul3SubAnd3(std::span< const uint32_t > vars) {
+            assert(vars.size() == kMul3SubAnd3Arity);
             return Expr::Add(
                 Expr::Mul(
                     Expr::Mul(Expr::Variable(vars[0]), Expr::Variable(vars[1])),
@@ -44,12 +64,12 @@ namespace cobra {
     const std::vector< GhostPrimitive > &GetGhostBasis() {
         static const std::vector< GhostPrimitive > kBasis = {
             {   .name      = "mul_sub_and",
-             .arity     = 2,
+             .arity     = kMulSubAndArity,
              .symmetric = true,
              .eval      = EvalMulSubAnd,
              .build     = BuildMulSubAnd  },
             { .name      = "mul3_sub_and3",
-             .arity     = 3,
+             .arity     = kMul3SubAnd3Arity,
              .symmetric = true,
              .eval      = EvalMul3SubAnd3,
              .build     = BuildMul3SubAnd3 },

--- a/lib/core/GhostBasis.cpp
+++ b/lib/core/GhostBasis.cpp
@@ -15,8 +15,7 @@ namespace cobra {
         constexpr uint8_t kMul3SubAnd3Arity = 3;
 
         static_assert(
-            kMulSubAndArity <= kMaxResidualSupport
-            && kMul3SubAnd3Arity <= kMaxResidualSupport,
+            kMulSubAndArity <= kMaxResidualSupport && kMul3SubAnd3Arity <= kMaxResidualSupport,
             "Ghost primitive arity exceeds kMaxResidualSupport — "
             "consumer buffers (combo, args, var_indices) would overflow"
         );

--- a/lib/core/GhostResidualSolver.cpp
+++ b/lib/core/GhostResidualSolver.cpp
@@ -28,7 +28,7 @@ namespace cobra {
         // Mixed parity gives varied 2-adic valuations.
         struct ProbePoint
         {
-            std::array< uint64_t, 6 > values{}; // max 6 vars
+            std::array< uint64_t, kMaxResidualSupport > values{};
         };
 
         constexpr int kNumProbes = 8;
@@ -62,8 +62,8 @@ namespace cobra {
                 9, 12, 17, 20, 25, 30, 35, 40, 47, 56, 63, 70, 79, 86, 95, 102,
             };
             for (size_t p = 0; p < kNumProbes; ++p) {
-                for (uint32_t v = 0; v < num_vars && v < 6; ++v) {
-                    bank[p].values[v] = kSeeds[(p * 6) + v] & kMask;
+                for (uint32_t v = 0; v < num_vars && v < kMaxResidualSupport; ++v) {
+                    bank[p].values[v] = kSeeds[(p * kMaxResidualSupport) + v] & kMask;
                 }
             }
         }
@@ -85,7 +85,7 @@ namespace cobra {
         // Condition 2: nonzero at some non-boolean full-width point
         // Probe in support-local space, map to full space via support[].
         const auto kSupportSize = static_cast< uint32_t >(support.size());
-        if (kSupportSize > 6) { return false; }
+        if (kSupportSize > kMaxResidualSupport) { return false; }
 
         std::array< ProbePoint, kNumProbes > bank{};
         GenerateProbeBank(bank, kSupportSize, bitwidth);
@@ -126,17 +126,17 @@ namespace cobra {
         }
 
         for (const auto &prim : basis) {
-            if (prim.arity > kSupportSize) { continue; }
+            if (prim.arity > kSupportSize || prim.arity > kMaxResidualSupport) { continue; }
 
             // Enumerate strictly increasing index combinations
-            std::array< uint32_t, 6 > combo{};
+            std::array< uint32_t, kMaxResidualSupport > combo{};
             for (uint8_t i = 0; i < prim.arity; ++i) { combo[i] = i; }
             auto combo_span = std::span< uint32_t >{ combo.data(), prim.arity };
 
             do {
                 // Evaluate ghost at each probe point
                 std::array< uint64_t, kNumProbes > g_vals{};
-                std::array< uint64_t, 6 > args{};
+                std::array< uint64_t, kMaxResidualSupport > args{};
                 for (int p = 0; p < kNumProbes; ++p) {
                     for (uint8_t a = 0; a < prim.arity; ++a) {
                         args[a] = bank[static_cast< size_t >(p)].values[combo[a]];
@@ -189,7 +189,7 @@ namespace cobra {
                 if (!cross_ok) { continue; }
 
                 // Build the expression: c * ghost(var_indices)
-                std::array< uint32_t, 6 > var_indices{};
+                std::array< uint32_t, kMaxResidualSupport > var_indices{};
                 for (uint8_t a = 0; a < prim.arity; ++a) { var_indices[a] = support[combo[a]]; }
                 auto ghost_expr =
                     prim.build(std::span< const uint32_t >{ var_indices.data(), prim.arity });
@@ -232,22 +232,22 @@ namespace cobra {
         const auto &basis       = GetGhostBasis();
 
         for (const auto &prim : basis) {
-            if (prim.arity > kSupportSize) { continue; }
+            if (prim.arity > kSupportSize || prim.arity > kMaxResidualSupport) { continue; }
 
             // Enumerate strictly increasing index combinations
-            std::array< uint32_t, 6 > combo{};
+            std::array< uint32_t, kMaxResidualSupport > combo{};
             for (uint8_t i = 0; i < prim.arity; ++i) { combo[i] = i; }
             auto combo_span = std::span< uint32_t >{ combo.data(), prim.arity };
 
             do {
                 // Map support-local combo to original-space variable indices
-                std::array< uint32_t, 6 > var_indices{};
+                std::array< uint32_t, kMaxResidualSupport > var_indices{};
                 for (uint8_t a = 0; a < prim.arity; ++a) { var_indices[a] = support[combo[a]]; }
 
                 // Build weight function from ghost primitive + tuple
                 WeightFn weight =
                     [&prim, combo](std::span< const uint64_t > args, uint32_t bw) -> uint64_t {
-                    std::array< uint64_t, 6 > ghost_args{};
+                    std::array< uint64_t, kMaxResidualSupport > ghost_args{};
                     for (uint8_t a = 0; a < prim.arity; ++a) { ghost_args[a] = args[combo[a]]; }
                     return prim.eval(
                         std::span< const uint64_t >{ ghost_args.data(), prim.arity }, bw


### PR DESCRIPTION
## Summary

Closes the **ghost-residual-arity** cluster (3 findings) from the 2026-05-04 audit. The residual-family solvers (ghost basis, factored ghost, residual polynomial recovery, `ExtractPolyCore`) cap support size at 6 to keep `SolveGhostResidual`'s `combo` / `args` / `var_indices` buffers and `ProbePoint::values` within fixed bounds. The constant `6` was duplicated across at least seven sites. The companion `GhostPrimitive::arity` contract — that each primitive's eval/build span is exactly the declared arity — was unenforced on either side, so a future basis entry with arity > 6 would silently never run today (skipped by support-size guard) but could corrupt stack memory if a caller ever passed a smaller cap.

Findings closed:
- `decomposition-engine-cross-4` — max_real_vars=6 cap enforced inconsistently across 5 residual passes
- `decomposition-engine-cross-1` — GhostPrimitive arity vs SolveGhostResidual fixed 6-element buffers
- `decomposition-engine-cross-3` — GhostPrimitive Eval/Build span-size contract is implicit

## Changes

- `inline constexpr uint32_t kMaxResidualSupport = 6;` declared in `GhostResidualSolver.h` and referenced from every site:
  - 4 residual-pass guards in `DecompositionPasses.cpp`
  - `ExtractPolyCore` in `DecompositionEngine.cpp`
  - `IsBooleanNullResidual` support-size check
  - `ProbePoint::values`, `combo`, `args`, `var_indices`, `ghost_args` array sizes
  - `prim.arity > kSupportSize` filters in `SolveGhostResidual` / `SolveFactoredGhostResidual` now also reject `prim.arity > kMaxResidualSupport`
- `GhostBasis.cpp` declares named arity constants (`kMulSubAndArity = 2`, `kMul3SubAnd3Arity = 3`), a `static_assert` that both fit in `kMaxResidualSupport`, and `assert(args.size() == arity)` at every eval/build entry. A future primitive that declares an arity > 6 either fails to compile or fails loud at runtime on a mis-sized span.

## Test plan

- [x] Full unit suite (1171 tests, dataset/diagnostic suites excluded) passes — every residual-family test path exercises the new constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)