### PR TITLE
fix: add arity-aware Evaluator ctor and tighten consumer arity gates

### DIFF
--- a/include/cobra/core/Evaluator.h
+++ b/include/cobra/core/Evaluator.h
@@ -4,6 +4,7 @@
 #include "cobra/core/Profile.h"
 
 #include <algorithm>
+#include <cassert>
 #include <concepts>
 #include <cstdint>
 #include <functional>
@@ -41,6 +42,18 @@ namespace cobra {
         Evaluator &operator=(const Evaluator &)     = default;
         Evaluator &operator=(Evaluator &&) noexcept = default;
 
+        // Function-based ctor with explicit arity. Prefer this overload
+        // wherever the caller knows how many inputs the closure expects;
+        // it makes InputArity() meaningful for the function-path branch
+        // so consumers (EvaluateBooleanSignature, FullWidthCheckEval)
+        // can size their input buffer correctly without HasCompiledExpr()
+        // guards.
+        explicit Evaluator(Function fn, uint32_t arity, EvaluatorTraceKind trace_kind)
+            : fn_(std::move(fn)), input_arity_(arity), trace_kind_(trace_kind) {}
+
+        // Legacy zero-arity ctor. Sets input_arity_ = 0, signalling
+        // "unknown arity — trust the caller's num_vars". Consumers that
+        // bound-check against InputArity() must accept 0 as a wildcard.
         explicit Evaluator(
             Function fn, EvaluatorTraceKind trace_kind = EvaluatorTraceKind::kNone
         )
@@ -131,6 +144,11 @@ namespace cobra {
             // remapped through the elimination pipeline).
             uint32_t buf_size = source_arity;
             for (uint32_t idx : idx_map) { buf_size = std::max(buf_size, idx + 1); }
+            // The remapped Evaluator expects exactly `idx_map.size()`
+            // inputs from its caller (the closure indexes
+            // reduced_vals[i] for i < idx_map.size()). Pass that as the
+            // declared arity so InputArity() is meaningful for the
+            // function-path branch too.
             return Evaluator(
                 [base, idx_map, original_vals = std::vector< uint64_t >(buf_size, 0)](
                     const std::vector< uint64_t > &reduced_vals
@@ -144,7 +162,7 @@ namespace cobra {
                     }
                     return result;
                 },
-                trace_kind
+                static_cast< uint32_t >(idx_map.size()), trace_kind
             );
         }
 
@@ -206,6 +224,13 @@ namespace cobra {
             const std::vector< uint64_t > *inputs = &vals;
 
             if (!input_map_.empty()) {
+                // Caller must supply at least one value per input_map_
+                // entry; the loop below indexes vals[i] for each entry.
+                // If vals is undersized, the read would be out-of-bounds.
+                assert(
+                    vals.size() >= input_map_.size()
+                    && "Evaluator::InvokeUntraced: vals smaller than remapped arity"
+                );
                 size_t remapped_arity = compiled_->arity;
                 for (uint32_t idx : input_map_) {
                     remapped_arity = std::max(remapped_arity, static_cast< size_t >(idx) + 1);

--- a/lib/core/SignatureChecker.cpp
+++ b/lib/core/SignatureChecker.cpp
@@ -275,7 +275,12 @@ namespace cobra {
             return CompileExpr(simplified, bitwidth);
         }();
 
-        if ((eval_original.HasCompiledExpr() && eval_original.InputArity() > num_vars)
+        // InputArity()==0 is the legacy "unknown arity" sentinel for
+        // function-path Evaluators constructed without a declared arity;
+        // accept that as a wildcard. Any other value must not exceed
+        // num_vars or the closure would index its private buffer past
+        // the caller-supplied input vector.
+        if ((eval_original.InputArity() != 0 && eval_original.InputArity() > num_vars)
             || simplified_eval.arity > num_vars)
         {
             auto result = CheckResult{ .passed = false, .failing_input = {} };

--- a/lib/core/SignatureEval.cpp
+++ b/lib/core/SignatureEval.cpp
@@ -120,6 +120,17 @@ namespace cobra {
 
     std::vector< uint64_t >
     EvaluateBooleanSignature(const Evaluator &eval, uint32_t num_vars, uint32_t bitwidth) {
+        // Enforce the producer/consumer arity contract on remapped or
+        // arity-aware Evaluators. Function-path Evaluators constructed
+        // without an explicit arity report InputArity() == 0 — accept
+        // those as a wildcard ("trust the caller's num_vars"). Any
+        // Evaluator that DOES report an arity must agree with num_vars,
+        // or the closure would index its private buffer past num_vars.
+        [[maybe_unused]] const auto kArity = eval.InputArity();
+        assert(
+            (kArity == 0 || kArity == num_vars)
+            && "EvaluateBooleanSignature: Evaluator arity disagrees with num_vars"
+        );
 #ifdef COBRA_SIG_STATS
         auto t0 = std::chrono::high_resolution_clock::now();
 #endif


### PR DESCRIPTION
## Summary

Closes the **evaluator-arity-contract** cluster (4 findings) from the 2026-05-04 audit. Function-based `Evaluator`s reported `InputArity() == 0`, so every downstream arity gate that conditioned on `HasCompiledExpr()` silently skipped the function-path side. `EvaluateBooleanSignature(Evaluator)` and `FullWidthCheckEval` would happily pass an undersized vector to a remapped function-path `Evaluator`, whose closure then indexed past the caller-supplied buffer. `Evaluator::Remap`'s function-path branch built its returned `Evaluator` without declaring the new arity, so `InputArity()` stayed at 0 even after `Remap`.

Findings closed:
- `lifting-passes-45` — Evaluator::InputArity returns 0 for function-based Evaluators
- `lifting-passes-47` — Evaluator::InvokeUntraced has no bounds-check on `vals`
- `lifting-passes-cross-2` — EvaluateBooleanSignature does not enforce evaluator_call_arity contract
- `lifting-passes-cross-5` — FullWidthCheckEval arity gate skipped for function-path Evaluators

## Changes

- New arity-aware ctor `Evaluator(Function fn, uint32_t arity, EvaluatorTraceKind trace_kind)`. The legacy zero-arity ctor stays for back-compat (test sites and the LLVM pass construct Evaluators via `opts.evaluator = lambda` and have no mechanical reason to know arity); `InputArity() == 0` is now treated as an explicit "trust the caller" wildcard.
- `Evaluator::Remap` function-path branch routes through the new ctor, passing `idx_map.size()` as the declared arity.
- `Evaluator::InvokeUntraced` asserts `vals.size() >= input_map_.size()` before indexing on the remapped path.
- `EvaluateBooleanSignature(Evaluator)` asserts `InputArity() == 0 || InputArity() == num_vars`.
- `FullWidthCheckEval` drops its `HasCompiledExpr()` guard — any non-zero `InputArity()` is now bound-checked uniformly.

## Test plan

- [x] Full unit suite (1171 tests, dataset/diagnostic suites excluded) passes — refactor exercised by every remapped-Evaluator call path (signature checker, lifted-skeleton residual recombine, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)