### PR TITLE
fix: document Evaluator thread-safety contract

### DIFF
--- a/include/cobra/core/Evaluator.h
+++ b/include/cobra/core/Evaluator.h
@@ -30,6 +30,33 @@ namespace cobra {
         std::vector< uint64_t > stack;
     };
 
+    // ---------------------------------------------------------------
+    // Thread-safety contract
+    // ---------------------------------------------------------------
+    // Evaluator instances are NOT thread-safe. Two threads calling
+    // operator() on the same instance race on:
+    //   1. The function-path closure built by Remap, whose `original_vals`
+    //      buffer is captured by-value (mutable per closure invocation).
+    //      The buffer is reset to 0 after each invocation, but neither
+    //      the write nor the reset is atomic.
+    //   2. The compiled-path workspace path: when no explicit
+    //      EvaluatorWorkspace is supplied, InvokeUntraced allocates a
+    //      local one — that's per-call safe — but callers that pass a
+    //      shared `EvaluatorWorkspace` for performance must not share
+    //      that workspace across threads.
+    //   3. BuildRemainderEvaluator (DecompositionEngine) returns a closure
+    //      capturing `original_workspace` and `core_stack` as mutable;
+    //      the same race applies to that closure.
+    //
+    // For cross-thread use, copy the Evaluator first — each copy holds
+    // an independent std::function (lambdas capture by value, so the
+    // `original_vals` and similar workspace buffers are duplicated). The
+    // shared_ptr<CompiledExpr> is a refcounted handle and is itself
+    // safe to share across threads as long as each thread owns its own
+    // EvaluatorWorkspace.
+    //
+    // The orchestrator is single-threaded today; the compiler enforces
+    // nothing about that, so this contract lives in documentation.
     class Evaluator
     {
       public:
@@ -131,6 +158,11 @@ namespace cobra {
             // remapped through the elimination pipeline).
             uint32_t buf_size = source_arity;
             for (uint32_t idx : idx_map) { buf_size = std::max(buf_size, idx + 1); }
+            // The captured `original_vals` is mutable: invocations write
+            // reduced_vals into it, then reset to 0 on exit. Concurrent
+            // calls on the same Evaluator instance race on this buffer
+            // — see the thread-safety contract above. Copy the Evaluator
+            // for per-thread use.
             return Evaluator(
                 [base, idx_map, original_vals = std::vector< uint64_t >(buf_size, 0)](
                     const std::vector< uint64_t > &reduced_vals

--- a/lib/core/DecompositionEngine.cpp
+++ b/lib/core/DecompositionEngine.cpp
@@ -85,6 +85,11 @@ namespace cobra {
     BuildRemainderEvaluator(const Evaluator &original, const Expr &core, uint32_t bitwidth) {
         auto compiled_core   = std::make_shared< CompiledExpr >(CompileExpr(core, bitwidth));
         const uint64_t kMask = Bitmask(bitwidth);
+        // The returned closure captures `original_workspace` and `core_stack`
+        // as mutable buffers reused across invocations. Concurrent calls on
+        // the same Evaluator race on those buffers — see the Evaluator
+        // thread-safety contract in Evaluator.h. Copy the Evaluator for
+        // per-thread use; lambda capture-by-value duplicates the workspaces.
         return Evaluator(
             [original, compiled_core = std::move(compiled_core), kMask,
              original_workspace = EvaluatorWorkspace{}, core_stack = std::vector< uint64_t >{}](


### PR DESCRIPTION
## Summary

Closes the **evaluator-thread-safety** cluster (3 findings) from the 2026-05-04 audit. `Evaluator`-family closures capture mutable buffers (`original_vals` in `Remap`'s function-path branch; `original_workspace` and `core_stack` in `BuildRemainderEvaluator`). Concurrent calls on the same instance race on those buffers, but neither the class header nor the call sites flagged the constraint, and `std::function` semantics suggest thread-safety to readers. The orchestrator is single-threaded today, so no live race exists, but the contract was implicit and hostile to future contributors.

Findings closed:
- `lifting-passes-34` — Evaluator copy constructor: no thread-safety documentation
- `lifting-passes-41` — Evaluator::Remap function-path closure captures mutable buffer
- `decomposition-engine-7` — BuildRemainderEvaluator closure captures mutable workspaces (Informational)

## Changes

- Added a class-level **Thread-safety contract** doc block on `Evaluator` spelling out (1) the function-path closure mutable buffer, (2) the compiled-path `EvaluatorWorkspace` ownership rule, and (3) the `BuildRemainderEvaluator` closure capture.
- Annotated the `Remap` function-path closure construction with a pointer-back to the contract.
- Annotated `BuildRemainderEvaluator`'s closure construction with the same pointer-back.

## Scope note

Documentation only; no behavioral or test changes. The closures still race if used concurrently. This PR makes the contract visible so a future contributor reaches for `thread_local` or per-thread copies deliberately rather than discovering the constraint from a heisenbug.

## Test plan

- [x] Full unit suite (1171 tests, dataset/diagnostic suites excluded) passes (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)