### PR TITLE
fix: use kResidualGateProbeCount=64 at post-solver verification gates

### DIFF
--- a/include/cobra/core/SignatureChecker.h
+++ b/include/cobra/core/SignatureChecker.h
@@ -7,6 +7,22 @@
 
 namespace cobra {
 
+    // Default probe count for FullWidthCheck / FullWidthCheckEval.
+    // Sufficient for shape-deterministic rewrites (e.g., AnfCleanup,
+    // RefoldNegation, single-pattern matchers) where the candidate's
+    // shape is fully determined by the input and only randomized
+    // sampling is needed to exercise full-width modular arithmetic.
+    inline constexpr uint32_t kDefaultProbeCount = 8;
+
+    // Strengthened probe count for "post-solver verification" gates —
+    // the boundary between a numeric solver (CoB, ANF→Mul shadow,
+    // singleton polynomial reconstruction, lifted-substitute) and
+    // candidate emission. The 64-probe count is the documented
+    // residual-gate strength: it catches boolean-correct /
+    // full-width-incorrect false positives that the 8-probe default
+    // fails to surface against shape-non-deterministic rewrites.
+    inline constexpr uint32_t kResidualGateProbeCount = 64;
+
     struct CheckResult
     {
         bool passed;

--- a/lib/core/AuxVarEliminator.cpp
+++ b/lib/core/AuxVarEliminator.cpp
@@ -1,5 +1,6 @@
 #include "cobra/core/AuxVarEliminator.h"
 #include "cobra/core/Profile.h"
+#include "cobra/core/SignatureChecker.h"
 #include "cobra/core/Trace.h"
 #include <algorithm>
 #include <bit>
@@ -71,7 +72,13 @@ namespace cobra {
         bool IsSpuriousFullWidth(
             const Evaluator &eval, uint32_t var_index, uint32_t num_vars, uint32_t bitwidth
         ) {
-            constexpr uint32_t kNumSamples = 8;
+            // 8 probes are enough for densely-dependent expressions
+            // (the {0,1} sig already disagrees) but can miss
+            // sparsely-dependent vars whose effect surfaces only on a
+            // small subset of full-width inputs. Match the residual
+            // gate's strength so the spurious-classification depth is
+            // uniform with downstream verification.
+            constexpr uint32_t kNumSamples = kResidualGateProbeCount;
             const uint64_t kMask = (bitwidth >= 64) ? UINT64_MAX : ((1ULL << bitwidth) - 1);
             uint64_t rng_state   = (static_cast< uint64_t >(var_index) * 2654435761ULL)
                 + (static_cast< uint64_t >(num_vars) * 40503ULL) + 0xDEADBEEFULL;

--- a/lib/core/SignaturePasses.cpp
+++ b/lib/core/SignaturePasses.cpp
@@ -619,8 +619,16 @@ namespace cobra {
                 return pr;
             }
             const auto num_vars = static_cast< uint32_t >(cont.original_vars.size());
-            auto check =
-                FullWidthCheckEval(*cont.original_eval, num_vars, *substituted, ctx.bitwidth);
+            // Post-solver verification gate: the substituted Expr fuses
+            // a winner candidate (chosen by signature competition) with
+            // its lifted bindings, which can introduce full-width
+            // disagreements not visible in the {0,1} signature space.
+            // Use the residual-gate probe count to match the sibling
+            // ResolveResidualRecombine (line 709 below).
+            auto check = FullWidthCheckEval(
+                *cont.original_eval, num_vars, *substituted, ctx.bitwidth,
+                kResidualGateProbeCount
+            );
             if (!check.passed) {
                 pr.decision = PassDecision::kBlocked;
                 pr.reason   = ReasonDetail{
@@ -1021,9 +1029,14 @@ namespace cobra {
             if (!fw.passed) {
                 // Product-shadow repair: AND = MUL on {0,1} but not
                 // at full width. Try replacing AND(var,var) with MUL.
+                // The repair sits on the AND/MUL semantic boundary
+                // V2 already flagged as a known divergence between
+                // {0,1} and full-width semantics, so verify with the
+                // residual-gate probe count rather than the default.
                 auto repaired = RepairProductShadow(CloneExpr(*anf_expr));
-                auto repair_fw =
-                    FullWidthCheckEval(*mapped_eval, num_vars, *repaired, ctx.bitwidth);
+                auto repair_fw = FullWidthCheckEval(
+                    *mapped_eval, num_vars, *repaired, ctx.bitwidth, kResidualGateProbeCount
+                );
                 if (repair_fw.passed) {
                     anf_expr = std::move(repaired);
                 } else {
@@ -1335,7 +1348,16 @@ namespace cobra {
             }
             if (!combined) { combined = Expr::Constant(0); }
 
-            auto fw = FullWidthCheckEval(*mapped_eval, num_vars, *combined, ctx.bitwidth);
+            // Override-path candidates take the recursive signature
+            // chain's residual-gate strength, matching the non-override
+            // path that emits a kRemainderState child whose
+            // ResolveResidualRecombine verifies at 64 probes. Without
+            // this, the override branch would commit a kVerified
+            // candidate after only 8 probes against a Mul(coeff, anf)
+            // shape that has known full-width false-positive risk.
+            auto fw = FullWidthCheckEval(
+                *mapped_eval, num_vars, *combined, ctx.bitwidth, kResidualGateProbeCount
+            );
             if (!fw.passed) {
                 return Ok(
                     PassResult{

--- a/lib/core/SignaturePasses.cpp
+++ b/lib/core/SignaturePasses.cpp
@@ -625,7 +625,7 @@ namespace cobra {
             // disagreements not visible in the {0,1} signature space.
             // Use the residual-gate probe count to match the sibling
             // ResolveResidualRecombine (line 709 below).
-            auto check = FullWidthCheckEval(
+            auto check          = FullWidthCheckEval(
                 *cont.original_eval, num_vars, *substituted, ctx.bitwidth,
                 kResidualGateProbeCount
             );
@@ -1033,7 +1033,7 @@ namespace cobra {
                 // V2 already flagged as a known divergence between
                 // {0,1} and full-width semantics, so verify with the
                 // residual-gate probe count rather than the default.
-                auto repaired = RepairProductShadow(CloneExpr(*anf_expr));
+                auto repaired  = RepairProductShadow(CloneExpr(*anf_expr));
                 auto repair_fw = FullWidthCheckEval(
                     *mapped_eval, num_vars, *repaired, ctx.bitwidth, kResidualGateProbeCount
                 );


### PR DESCRIPTION
## Summary

Closes the **verification-probe-depth** cluster (4 findings) from the 2026-05-04 audit. Several post-solver verification sites left `FullWidthCheckEval` at the default 8-probe count while siblings on the same boundary used 64 — asymmetric verification depth without justification in the code or comments. The 64-probe count is the documented "residual-gate strength" that catches boolean-correct / full-width-incorrect false positives; the 8-probe default is for shape-deterministic rewrites.

Findings closed:
- `signature-basis-55` — ResolveLiftedSubstitute used 8 probes; sibling ResolveResidualRecombine uses 64
- `signature-basis-cross-2` — Singleton override-path bypassed the 64-probe residual gate
- `signature-basis-cross-3` — RunSignatureAnf accepted ProductShadow-repaired Expr after only 8 probes
- `expr-foundation-5` — IsSpuriousFullWidth 8-probe sample insufficient for sparse-dependence

## Changes

- `SignatureChecker.h` declares `inline constexpr uint32_t kDefaultProbeCount = 8;` and `kResidualGateProbeCount = 64;`
- `ResolveLiftedSubstitute`'s post-substitution verifier passes `kResidualGateProbeCount` (matches the sibling residual-recombine site at line 709)
- `RunSignatureSingletonPolyRecovery` override-path passes `kResidualGateProbeCount` (matches the non-override path's recursive residual gate)
- `RunSignatureAnf`'s `RepairProductShadow` re-verifier passes `kResidualGateProbeCount` — the AND/MUL semantic boundary V2 already flagged as a known divergence
- `IsSpuriousFullWidth`'s per-variable probe uses `kResidualGateProbeCount` (was 8)

## Test plan

- [x] Full unit suite (1171 tests, dataset/diagnostic suites excluded) passes — the strengthened verification surfaced no test deltas

🤖 Generated with [Claude Code](https://claude.com/claude-code)