### PR TITLE
fix: tighten docstrings and labels that drift from implementation

### DIFF
--- a/include/cobra/core/ExprUtils.h
+++ b/include/cobra/core/ExprUtils.h
@@ -28,13 +28,23 @@ namespace cobra {
     bool IsConstantSubtree(const Expr &expr);
 
     /// Evaluate a constant-only Expr subtree (no variables allowed).
-    /// Throws std::runtime_error if a Variable node is encountered.
     /// Result is masked to Bitmask(bitwidth).
+    /// Behavior is undefined if a Variable node is encountered (the
+    /// implementation invokes std::unreachable() on the variable case).
+    /// Use IsConstantSubtree() to verify before calling.
     uint64_t EvalConstantExpr(const Expr &expr, uint32_t bitwidth);
 
     /// Cosmetic cleanup on the final simplified expression.
-    /// Chains: constant folding → negation refolding.
-    /// Semantics-preserving, no verification needed.
+    /// Chains: constant folding → negation refolding → ExtractCommonFactor
+    /// → constant folding.
+    ///
+    /// Semantics-preserving under the assumption that std::hash<Expr>
+    /// does not collide on the input AST. ExtractCommonFactor uses
+    /// hash-based factor equality, so a hash collision could in
+    /// principle produce a non-equivalent rewrite. The hash-collision
+    /// tradeoff is accepted at the project level (see audit
+    /// 2026-05-04 lifting-passes-29 / -65). Callers requiring strict
+    /// semantics-preservation must re-verify the result.
     std::unique_ptr< Expr > CleanupFinalExpr(std::unique_ptr< Expr > expr, uint32_t bitwidth);
 
     /// Check if an Expr subtree depends on any variable.
@@ -45,8 +55,16 @@ namespace cobra {
     bool HasNonleafBitwise(const Expr &expr);
 
     /// Replace AND(var-dep, var-dep) with MUL in an expression tree.
-    /// Corrects the product-shadow divergence where AND = MUL on {0,1}
-    /// but not at full width.
+    /// The rewrite `AND(P, Q) → MUL(P, Q)` is the identity `x AND y == x * y`
+    /// only when both x and y are individually in {0, 1}. At full width,
+    /// the rewrite is unsound: `2 AND 2 = 2 ≠ 2 * 2 = 4`.
+    ///
+    /// CALLER OBLIGATION: this is a candidate-shape rewrite, not a
+    /// semantics-preserving repair. The result MUST be verified at full
+    /// width (e.g., FullWidthCheckEval with kResidualGateProbeCount)
+    /// before being accepted as a verified candidate. Production
+    /// callers (RunSignatureAnf) re-verify; tests and direct callers
+    /// must do the same.
     std::unique_ptr< Expr > RepairProductShadow(std::unique_ptr< Expr > expr);
 
 } // namespace cobra

--- a/lib/core/DecompositionEngine.cpp
+++ b/lib/core/DecompositionEngine.cpp
@@ -100,6 +100,15 @@ namespace cobra {
         );
     }
 
+    // Extracts product addends from the AST and assembles them into a
+    // sum-of-products `core` expression. ExtractorKind::kProductAST is
+    // the classification label, but the extracted core may include
+    // wrappers around products: SplitAddTree's IsProductAddend accepts
+    // Mul(a, b), Neg(Mul(a, b)), and Not(Mul(a, b)) (which is
+    // `-Mul(a, b) - 1`). Neg/Not subtrees go into the core verbatim,
+    // and the residual evaluator subtracts the full-width value, so
+    // the wrappers' offsets are correctly accounted. The label remains
+    // `kProductAST` despite the Neg/Not wrapping.
     SolverResult< CoreCandidate > ExtractProductCore(const DecompositionContext &ctx) {
         COBRA_ZONE_N("ExtractProductCore");
         if (ctx.current_expr == nullptr) {

--- a/lib/core/SemilinearPasses.cpp
+++ b/lib/core/SemilinearPasses.cpp
@@ -232,6 +232,16 @@ namespace cobra {
         return Ok(std::move(result));
     }
 
+    // Self-check pass for the normalized semilinear IR. Despite the
+    // name, this pass DOES mutate the IR before checking: SimplifyStructure
+    // runs first to merge like atoms, recognize complement-pairs, and
+    // apply per-atom algebraic identities (De Morgan, double-NOT, etc.).
+    // The self-check then validates the post-SimplifyStructure form
+    // against the original AST, and the CheckedSemilinearPayload that
+    // flows downstream carries that mutated IR. RecoverStructure (later
+    // in the pipeline) reads the SimplifyStructure-rewritten atoms via
+    // DecomposeAtom — so the semilinear pipeline's "structural"
+    // transforms in fact begin here, not at RunSemilinearRewrite.
     Result< PassResult > RunSemilinearCheck(const WorkItem &item, OrchestratorContext &ctx) {
         COBRA_ZONE_N("RunSemilinearCheck");
         if (!std::holds_alternative< NormalizedSemilinearPayload >(item.payload)) {

--- a/lib/core/SignaturePasses.cpp
+++ b/lib/core/SignaturePasses.cpp
@@ -155,6 +155,10 @@ namespace cobra {
             const WorkItem &item, const SignatureSubproblemContext &sub_ctx
         ) {
             const auto num_vars = sub_ctx.real_vars.size();
+            // Fast-path is intentionally narrower than
+            // RunSignatureMultivarPolyRecovery's 6-var envelope: 5-6 var
+            // problems get the worklist pipeline's full classification
+            // context. See SignaturePasses.h coverage note.
             if (num_vars < 2 || num_vars > 4 || !item.features.classification) { return false; }
 
             const auto &cls = *item.features.classification;

--- a/lib/core/SignaturePasses.h
+++ b/lib/core/SignaturePasses.h
@@ -9,6 +9,12 @@ namespace cobra {
     // Returns a verified direct candidate when the existing polynomial
     // passes can solve the reduced problem inline without entering the
     // signature competition worklist.
+    //
+    // Coverage: num_vars == 1 (univariate fast-path) and 2 <= num_vars <= 4
+    // (multivar fast-path). num_vars in [5, 6] falls through to the worklist
+    // pipeline (RunSignatureMultivarPolyRecovery), which handles those vars
+    // with full classification context. Widening the fast-path to 5-6 vars
+    // would require matching that envelope here.
     std::optional< CandidateRecord >
     TryReducedPolynomialFastPath(const WorkItem &item, OrchestratorContext &ctx);
 


### PR DESCRIPTION
## Summary

Closes the **doc-implementation-drift** cluster (7 findings) from the 2026-05-04 audit. Several public-API docstrings and classification labels overstated or contradicted the actual function behavior — guarantees that depended on rejected hash-collision tradeoffs, "throws" claims that compiled to `std::unreachable()`, pass-name claims contradicted by IR mutation, and classification labels that included shapes the label rules out.

Findings closed:
- `lifting-passes-21` — EvalConstantExpr docstring claims throws, code uses std::unreachable() (UB on misuse)
- `lifting-passes-30` — CleanupFinalExpr "no verification needed" docstring inherits ExtractCommonFactor's hash-collision risk
- `lifting-passes-32` — RepairProductShadow underspecifies the {0,1}-only caller obligation
- `lifting-passes-cross-3` — CleanupFinalExpr docstring contradicts ExtractCommonFactor; orchestrator caller relies on the false guarantee
- `signature-basis-40` — TryReducedPolynomialFastPath header has no coverage range; gate is 2-4 (Informational)
- `semilinear-decomposition-cross-1` — RunSemilinearCheck mutates IR via SimplifyStructure, contradicts the pass-name claim
- `decomposition-engine-2` — kProductAST label inaccurate for Not(Mul) / Neg(Mul) addends (Informational)

## Changes

- `EvalConstantExpr` — docstring documents UB on Variable, points to `IsConstantSubtree`.
- `CleanupFinalExpr` — docstring explicitly notes the hash-collision dependency and that callers requiring strict semantics-preservation must re-verify.
- `RepairProductShadow` — docstring spells out the `{0,1}`-only soundness boundary and the caller's obligation to re-verify at full width.
- `TryReducedPolynomialFastPath` — adds coverage range note (2-4 vars; 5-6 fall through to worklist) at both header and `IsMultivarPolynomialFastPathCandidate` gate.
- `RunSemilinearCheck` — header comment explains `SimplifyStructure` runs first and the `CheckedSemilinearPayload` carries the mutated IR.
- `ExtractProductCore` — explains `kProductAST` keeps the label despite `Neg(Mul)` / `Not(Mul)` wrappers in the extracted core.

## Test plan

- [x] Full unit suite (1171 tests, dataset/diagnostic suites excluded) passes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)