### PR TITLE
refactor: canonicalize ContainsShr and CollectVariables in ExprUtils

### DIFF
--- a/include/cobra/core/DynamicMask.h
+++ b/include/cobra/core/DynamicMask.h
@@ -28,7 +28,4 @@ namespace cobra {
     // the inner expression g.
     std::optional< MaskInfo > DetectRootLowBitMask(const Expr &expr, uint32_t bitwidth);
 
-    // Returns true if any node in the AST is kShr.
-    bool ContainsShr(const Expr &expr);
-
 } // namespace cobra

--- a/include/cobra/core/ExprUtils.h
+++ b/include/cobra/core/ExprUtils.h
@@ -27,6 +27,14 @@ namespace cobra {
     /// Check if an Expr subtree contains only constants (no variables).
     bool IsConstantSubtree(const Expr &expr);
 
+    /// Returns true if any node in the AST is kShr.
+    bool ContainsShr(const Expr &expr);
+
+    /// Append the var_index of every kVariable node (pre-order). Duplicates
+    /// are preserved; callers that want a deduplicated support set must
+    /// sort + unique the output themselves.
+    void CollectVariables(const Expr &expr, std::vector< uint32_t > &out);
+
     /// Evaluate a constant-only Expr subtree (no variables allowed).
     /// Result is masked to Bitmask(bitwidth).
     /// Behavior is undefined if a Variable node is encountered (the

--- a/include/cobra/core/SemilinearIR.h
+++ b/include/cobra/core/SemilinearIR.h
@@ -77,9 +77,6 @@ namespace cobra {
     /// Returns invalid for opaque atoms that don't fit this pattern.
     Decomposed DecomposeAtom(const AtomInfo &info, uint64_t modmask);
 
-    /// Collect variable indices from an expression tree.
-    void CollectVarsFromExpr(const Expr &expr, std::vector< GlobalVarIdx > &out);
-
     /// Create a new atom entry in the IR and return its ID.
     AtomId
     CreateAtom(SemilinearIR &ir, std::unique_ptr< Expr > subtree, OperatorFamily provenance);

--- a/lib/core/DynamicMask.cpp
+++ b/lib/core/DynamicMask.cpp
@@ -40,12 +40,4 @@ namespace cobra {
         return MaskInfo{ .effective_width = *m, .inner = other_child };
     }
 
-    bool ContainsShr(const Expr &expr) {
-        if (expr.kind == Expr::Kind::kShr) { return true; }
-        for (const auto &child : expr.children) {
-            if (ContainsShr(*child)) { return true; }
-        }
-        return false;
-    }
-
 } // namespace cobra

--- a/lib/core/ExprUtils.cpp
+++ b/lib/core/ExprUtils.cpp
@@ -60,6 +60,21 @@ namespace cobra {
         });
     }
 
+    bool ContainsShr(const Expr &expr) {
+        if (expr.kind == Expr::Kind::kShr) { return true; }
+        return std::ranges::any_of(expr.children, [](const auto &child) {
+            return ContainsShr(*child);
+        });
+    }
+
+    void CollectVariables(const Expr &expr, std::vector< uint32_t > &out) {
+        if (expr.kind == Expr::Kind::kVariable) {
+            out.push_back(expr.var_index);
+            return;
+        }
+        for (const auto &child : expr.children) { CollectVariables(*child, out); }
+    }
+
     uint64_t EvalConstantExpr(const Expr &expr, uint32_t bitwidth) {
         const uint64_t kMask = Bitmask(bitwidth);
 

--- a/lib/core/SemilinearIR.cpp
+++ b/lib/core/SemilinearIR.cpp
@@ -117,18 +117,10 @@ namespace cobra {
         return {};
     }
 
-    void CollectVarsFromExpr(const Expr &expr, std::vector< GlobalVarIdx > &out) {
-        if (expr.kind == Expr::Kind::kVariable) {
-            out.push_back(expr.var_index);
-            return;
-        }
-        for (const auto &child : expr.children) { CollectVarsFromExpr(*child, out); }
-    }
-
     AtomId
     CreateAtom(SemilinearIR &ir, std::unique_ptr< Expr > subtree, OperatorFamily provenance) {
         std::vector< GlobalVarIdx > support;
-        CollectVarsFromExpr(*subtree, support);
+        CollectVariables(*subtree, support);
         std::sort(support.begin(), support.end());
         support.erase(std::unique(support.begin(), support.end()), support.end());
 

--- a/lib/core/SemilinearNormalizer.cpp
+++ b/lib/core/SemilinearNormalizer.cpp
@@ -1,6 +1,7 @@
 #include "cobra/core/SemilinearNormalizer.h"
 #include "cobra/core/BitWidth.h"
 #include "cobra/core/Expr.h"
+#include "cobra/core/ExprUtils.h"
 #include "cobra/core/Result.h"
 #include "cobra/core/SemilinearIR.h"
 #include "cobra/core/Trace.h"
@@ -72,13 +73,6 @@ namespace cobra {
             return 0;
         }
 
-        bool ContainsShr(const Expr &expr) {
-            if (expr.kind == Expr::Kind::kShr) { return true; }
-            return std::ranges::any_of(expr.children, [](const auto &child) {
-                return ContainsShr(*child);
-            });
-        }
-
         uint64_t EvalConstantArith(const Expr &expr, uint64_t mask, uint32_t bitwidth) {
             switch (expr.kind) {
                 case Expr::Kind::kConstant:
@@ -113,14 +107,6 @@ namespace cobra {
                     break;
             }
             return 0;
-        }
-
-        void CollectVariables(const Expr &expr, std::vector< GlobalVarIdx > &out) {
-            if (expr.kind == Expr::Kind::kVariable) {
-                out.push_back(expr.var_index);
-                return;
-            }
-            for (const auto &child : expr.children) { CollectVariables(*child, out); }
         }
 
         bool HasConstant(const Expr &expr) {

--- a/lib/core/StructureRecovery.cpp
+++ b/lib/core/StructureRecovery.cpp
@@ -1,6 +1,7 @@
 #include "cobra/core/StructureRecovery.h"
 #include "cobra/core/BitWidth.h"
 #include "cobra/core/Expr.h"
+#include "cobra/core/ExprUtils.h"
 #include "cobra/core/SemilinearIR.h"
 #include "cobra/core/SignatureChecker.h"
 #include "cobra/core/Trace.h"
@@ -75,13 +76,6 @@ namespace cobra {
                     return a.atom_id < b.atom_id;
                 }
             );
-        }
-
-        bool HasShr(const Expr &expr) {
-            if (expr.kind == Expr::Kind::kShr) { return true; }
-            return std::ranges::any_of(expr.children, [](const auto &child) {
-                return HasShr(*child);
-            });
         }
 
     } // namespace
@@ -329,7 +323,7 @@ namespace cobra {
             // Only flatten single-variable atoms without shifts.
             // Shifts mix bits across positions, breaking the per-bit
             // decomposition f(x) = f(0) + (x & pass) - (x & invert).
-            if (info.key.support.size() != 1 || HasShr(*info.original_subtree)) {
+            if (info.key.support.size() != 1 || ContainsShr(*info.original_subtree)) {
                 new_terms.push_back(term);
                 continue;
             }

--- a/test/bench/bench_mask_audit.cpp
+++ b/test/bench/bench_mask_audit.cpp
@@ -10,6 +10,7 @@
 #include "cobra/core/DynamicMask.h"
 #include "cobra/core/Expr.h"
 #include "cobra/core/ExprCost.h"
+#include "cobra/core/ExprUtils.h"
 #include "cobra/core/PatternMatcher.h"
 #include "cobra/core/SignatureEval.h"
 #include "cobra/core/Simplifier.h"

--- a/test/core/test_dynamic_mask.cpp
+++ b/test/core/test_dynamic_mask.cpp
@@ -1,5 +1,6 @@
 #include "cobra/core/DynamicMask.h"
 #include "cobra/core/Expr.h"
+#include "cobra/core/ExprUtils.h"
 #include <gtest/gtest.h>
 
 using namespace cobra;


### PR DESCRIPTION
## Summary
- Three near-identical Shr-detection predicates (`DynamicMask::ContainsShr`, `StructureRecovery::HasShr`, `SemilinearNormalizer::ContainsShr`) collapse to a single canonical `ContainsShr` in `ExprUtils`.
- Two near-identical variable-collection helpers (`SemilinearIR::CollectVarsFromExpr`, `SemilinearNormalizer::CollectVariables`) collapse to a single `CollectVariables` in `ExprUtils`.
- Closes audit findings `semilinear-decomposition-cross-3`, `-6`, and `-5`.

## Test plan
- [x] Unit tests for `DynamicMaskTest`, `SemilinearIRTest`, `SemilinearNormalizerTest`, `StructureRecoveryTest` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)