### PR TITLE
refactor: route inline bitmask reimplementations through Bitmask/SignBitMask

### DIFF
--- a/include/cobra/core/BitWidth.h
+++ b/include/cobra/core/BitWidth.h
@@ -9,6 +9,15 @@ namespace cobra {
         return (1ULL << bitwidth) - 1;
     }
 
+    // Mask with the sign bit set (1 << (bitwidth - 1)), guarded so that
+    // bitwidth==0 returns 0 rather than triggering shift UB. Use for
+    // negative-constant detection paired with Bitmask(bitwidth).
+    inline uint64_t SignBitMask(uint32_t bitwidth) {
+        if (bitwidth == 0) { return 0; }
+        if (bitwidth >= 64) { return 1ULL << 63; }
+        return 1ULL << (bitwidth - 1);
+    }
+
     inline uint64_t ModAdd(uint64_t a, uint64_t b, uint32_t bitwidth) {
         return (a + b) & Bitmask(bitwidth);
     }

--- a/include/cobra/core/MathUtils.h
+++ b/include/cobra/core/MathUtils.h
@@ -43,7 +43,7 @@ namespace cobra {
     inline uint64_t ModInverseOdd(uint64_t x, uint32_t bits) {
         assert(bits >= 1);
         assert(x & 1);
-        const uint64_t kModMask = (bits >= 64) ? UINT64_MAX : (1ULL << bits) - 1;
+        const uint64_t kModMask = Bitmask(bits);
         uint64_t inv            = x & kModMask;
         for (uint32_t b = 3; b < bits; b *= 2) { inv = (inv * (2 - (x * inv))) & kModMask; }
         return inv & kModMask;

--- a/lib/core/AuxVarEliminator.cpp
+++ b/lib/core/AuxVarEliminator.cpp
@@ -83,7 +83,7 @@ namespace cobra {
             // uniform with downstream verification.
             constexpr uint32_t kNumSamples = kResidualGateProbeCount;
             const uint64_t kMask           = Bitmask(bitwidth);
-            uint64_t rng_state   = (static_cast< uint64_t >(var_index) * 2654435761ULL)
+            uint64_t rng_state = (static_cast< uint64_t >(var_index) * 2654435761ULL)
                 + (static_cast< uint64_t >(num_vars) * 40503ULL) + 0xDEADBEEFULL;
 
             std::vector< uint64_t > inputs(num_vars);

--- a/lib/core/AuxVarEliminator.cpp
+++ b/lib/core/AuxVarEliminator.cpp
@@ -1,4 +1,5 @@
 #include "cobra/core/AuxVarEliminator.h"
+#include "cobra/core/BitWidth.h"
 #include "cobra/core/Profile.h"
 #include "cobra/core/Trace.h"
 #include <algorithm>
@@ -72,7 +73,7 @@ namespace cobra {
             const Evaluator &eval, uint32_t var_index, uint32_t num_vars, uint32_t bitwidth
         ) {
             constexpr uint32_t kNumSamples = 8;
-            const uint64_t kMask = (bitwidth >= 64) ? UINT64_MAX : ((1ULL << bitwidth) - 1);
+            const uint64_t kMask = Bitmask(bitwidth);
             uint64_t rng_state   = (static_cast< uint64_t >(var_index) * 2654435761ULL)
                 + (static_cast< uint64_t >(num_vars) * 40503ULL) + 0xDEADBEEFULL;
 

--- a/lib/core/Expr.cpp
+++ b/lib/core/Expr.cpp
@@ -84,8 +84,7 @@ namespace cobra {
                     // representable sign bit at bitwidth=0).
                     const uint64_t kMask = Bitmask(bitwidth);
                     const uint64_t kHalf = SignBitMask(bitwidth);
-                    if (kHalf != 0 && expr.constant_val >= kHalf
-                        && expr.constant_val <= kMask)
+                    if (kHalf != 0 && expr.constant_val >= kHalf && expr.constant_val <= kMask)
                     {
                         const uint64_t kNeg = (kMask - expr.constant_val) + 1;
                         out << "-" << kNeg;

--- a/lib/core/Expr.cpp
+++ b/lib/core/Expr.cpp
@@ -1,4 +1,5 @@
 #include "cobra/core/Expr.h"
+#include "cobra/core/BitWidth.h"
 #include <cstdint>
 #include <memory>
 #include <sstream>
@@ -78,18 +79,14 @@ namespace cobra {
         ) {
             switch (expr.kind) {
                 case Expr::Kind::kConstant: {
-                    // bitwidth==0 has no representable sign bit; render as
-                    // plain decimal to avoid UB in `1ULL << (bitwidth - 1)`
-                    // (the uint32 underflow would shift by 0xFFFFFFFF).
-                    if (bitwidth == 0) {
-                        out << expr.constant_val;
-                        break;
-                    }
-                    const uint64_t kMask =
-                        (bitwidth >= 64) ? UINT64_MAX : (1ULL << bitwidth) - 1;
-                    const uint64_t kHalf =
-                        (bitwidth >= 64) ? (1ULL << 63) : (1ULL << (bitwidth - 1));
-                    if (expr.constant_val >= kHalf && expr.constant_val <= kMask) {
+                    // SignBitMask(0) returns 0, which causes the
+                    // negative-detection branch to fall through (no
+                    // representable sign bit at bitwidth=0).
+                    const uint64_t kMask = Bitmask(bitwidth);
+                    const uint64_t kHalf = SignBitMask(bitwidth);
+                    if (kHalf != 0 && expr.constant_val >= kHalf
+                        && expr.constant_val <= kMask)
+                    {
                         const uint64_t kNeg = (kMask - expr.constant_val) + 1;
                         out << "-" << kNeg;
                     } else {


### PR DESCRIPTION
## Summary
- `RenderImpl`, `ModInverseOdd`, and `IsSpuriousFullWidth` each inlined `(bw >= 64) ? UINT64_MAX : (1ULL << bw) - 1`. Replace with `Bitmask()` calls.
- Add `SignBitMask(bw)` helper for negative-constant detection (returns 0 at bitwidth=0 to drop the explicit guard from `RenderImpl`).
- Closes audit finding `expr-foundation-cross-1`.

## Test plan
- [x] `ExprTest`, `AuxVarEliminatorTest`, `MathUtilsTest` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)