### PR TITLE
fix: convert CountNodes to iterative pre-order walk

### DIFF
--- a/lib/core/LiftingPasses.cpp
+++ b/lib/core/LiftingPasses.cpp
@@ -185,9 +185,19 @@ namespace cobra {
             for (const auto &c : e.children) { CollectVarSupport(*c, out); }
         }
 
+        // Iterative pre-order walk: this function gates the
+        // 50 000-node limit before subsequent recursive helpers run,
+        // so it must itself tolerate adversarially deep input ASTs
+        // that would blow a recursive call stack.
         uint32_t CountNodes(const Expr &e) {
-            uint32_t count = 1;
-            for (const auto &c : e.children) { count += CountNodes(*c); }
+            uint32_t count = 0;
+            std::vector< const Expr * > stack{ &e };
+            while (!stack.empty()) {
+                const Expr *node = stack.back();
+                stack.pop_back();
+                ++count;
+                for (const auto &c : node->children) { stack.push_back(c.get()); }
+            }
             return count;
         }
 


### PR DESCRIPTION
## Summary
- `CountNodes` is the size guard at `LiftingPasses.cpp:434` used to bound subsequent recursive helpers to <=50 000 nodes; it was itself recursive in tree depth, so an adversarially deep AST overflowed the stack inside the guard before it could reject the input.
- Convert to an explicit-stack pre-order walk.
- Closes audit finding `lifting-passes-10`.

## Test plan
- [x] `RepeatedSubexprLifter`, `ArithmeticAtomLifter` tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)