### PR TITLE
perf: store PassAttemptCache as uint64_t bitmask per fingerprint

### DIFF
--- a/lib/core/Orchestrator.cpp
+++ b/lib/core/Orchestrator.cpp
@@ -304,14 +304,13 @@ size_t std::hash< cobra::SemilinearFingerprintKey >::operator()(
 namespace cobra {
 
     void PassAttemptCache::Record(const StateFingerprint &fp, PassId pass) {
-        cache_[fp].push_back(pass);
+        cache_[fp] |= (uint64_t{ 1 } << static_cast< uint8_t >(pass));
     }
 
     bool PassAttemptCache::HasAttempted(const StateFingerprint &fp, PassId pass) const {
         auto it = cache_.find(fp);
         if (it == cache_.end()) { return false; }
-        const auto &passes = it->second;
-        return std::find(passes.begin(), passes.end(), pass) != passes.end();
+        return (it->second & (uint64_t{ 1 } << static_cast< uint8_t >(pass))) != 0;
     }
 
     void Worklist::Push(WorkItem item) {

--- a/lib/core/Orchestrator.h
+++ b/lib/core/Orchestrator.h
@@ -405,7 +405,12 @@ namespace cobra {
         bool HasAttempted(const StateFingerprint &fp, PassId pass) const;
 
       private:
-        absl::flat_hash_map< StateFingerprint, std::vector< PassId > > cache_;
+        // Bitmask keyed per fingerprint — PassId fits in 64 entries by
+        // construction (see static_assert in OrchestratorPasses.h), so a
+        // single uint64_t per fingerprint is enough. This makes Record /
+        // HasAttempted O(1) and prevents the unbounded vector growth a
+        // future fingerprint refactor could otherwise expose.
+        absl::flat_hash_map< StateFingerprint, uint64_t > cache_;
     };
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `Record`/`HasAttempted` previously used `vector<PassId>` per fingerprint with linear find. Repeated records pushed duplicates without a contains check, growing the vector unboundedly; `HasAttempted`'s linear scan amplified the cost.
- `PassId` is bounded to 64 entries by `static_assert` in `OrchestratorPasses.h`, so a single `uint64_t` bitmask collapses both operations to O(1).
- Closes audit finding `orchestrator-core-2`.

## Test plan
- [x] `OrchestratorTypes`, `CompetitionGroup` tests (36 total) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)