### PR TITLE
fix: walk both children when measuring OR-chain depth

### DIFF
--- a/lib/core/AnfCleanup.cpp
+++ b/lib/core/AnfCleanup.cpp
@@ -76,7 +76,11 @@ namespace cobra {
 
         uint32_t CountOrChainDepth(const Expr &expr) {
             if (expr.kind != Expr::Kind::kOr) { return 0; }
-            return 1 + CountOrChainDepth(*expr.children[0]);
+            uint32_t deepest = 0;
+            for (const auto &child : expr.children) {
+                deepest = std::max(deepest, CountOrChainDepth(*child));
+            }
+            return 1 + deepest;
         }
 
         std::optional< uint32_t > DetectOrFamily(const std::vector< uint32_t > &monomials) {


### PR DESCRIPTION
## Summary
- `CountOrChainDepth` recursed into `expr.children[0]` only, so the cost discount applied to left-skewed OR chains (which `BuildOrChain` happens to emit) but silently skipped right-skewed chains from any other producer.
- Walk both children and take the deeper spine.
- Closes audit finding `signature-basis-12`.

## Test plan
- [x] `ExprCost`, `AnfCleanup`, `Simplifier` tests (133 total) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)