### PR TITLE
ci: exclude SiMBAExprDataset from PR test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Run tests
         if: ${{ !matrix.release_only || startsWith(github.ref, 'refs/tags/v') }}
-        run: ctest --test-dir build -j "$(nproc 2>/dev/null || sysctl -n hw.ncpu)" --output-on-failure -E "DatasetBenchmark|SiMBADataset|GAMBADataset|OSESDataset|ObfuscatorXDataset"
+        run: ctest --test-dir build -j "$(nproc 2>/dev/null || sysctl -n hw.ncpu)" --output-on-failure -E "DatasetBenchmark|SiMBADataset|SiMBAExprDataset|GAMBADataset|OSESDataset|ObfuscatorXDataset"
 
   lint:
     name: Lint


### PR DESCRIPTION
## Summary
- The existing exclusion regex matches `SiMBADataset` literally, but the parameterized 16-case suite is named `SiMBAExprDataset` (`test/verify/test_dataset_benchmarks.cpp:224`). It silently leaked into every PR build, each instance running the full SiMBA pipeline over ~1000 expressions.
- Add `SiMBAExprDataset` to the ctest `-E` regex.

## Test plan
- [x] `ctest -N -E "...|SiMBAExprDataset|..."` confirms no `SiMBA*` cases remain in the kept set.
- [x] `actionlint` clean on the modified workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)