### PR TITLE
fix(deps): only require LLVM when building the LLVM pass

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -6,6 +6,7 @@
 #   cmake --build build-deps
 #
 # Options:
+#   COBRA_BUILD_LLVM_PASS   (default OFF) - Provide LLVM for the pass plugin
 #   USE_EXTERNAL_LLVM       (default ON)  - Use system LLVM vs build from source
 #   USE_EXTERNAL_HIGHWAY    (default OFF) - Use system highway vs build from source
 #   COBRA_BUILD_TESTS       (default OFF) - Build GoogleTest for tests
@@ -16,6 +17,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(cobra-dependencies LANGUAGES C CXX)
 
+option(COBRA_BUILD_LLVM_PASS "Build the LLVM pass plugin (requires LLVM 19-22)" OFF)
 option(USE_EXTERNAL_LLVM "Use system LLVM instead of building from source" ON)
 option(USE_EXTERNAL_ABSEIL "Use system abseil instead of building from source" OFF)
 option(USE_EXTERNAL_HIGHWAY "Use system highway instead of building from source" OFF)
@@ -28,7 +30,16 @@ include(superbuild.cmake)
 
 include(abseil.cmake)
 include(highway.cmake)
-include(llvm.cmake)
+
+# LLVM is needed only by the pass plugin, which the main project already gates
+# on COBRA_BUILD_LLVM_PASS (CMakeLists.txt:64).  Including it unconditionally
+# here made every dependency build either require a system LLVM install
+# (USE_EXTERNAL_LLVM=ON -> find_package(LLVM REQUIRED)) or build LLVM from
+# source -- neither of which cobra-core needs: libcobra-core.a references zero
+# LLVM symbols.
+if(COBRA_BUILD_LLVM_PASS)
+    include(llvm.cmake)
+endif()
 
 if(COBRA_BUILD_TESTS)
     include(googletest.cmake)


### PR DESCRIPTION
## Problem

`dependencies/CMakeLists.txt` includes `llvm.cmake` unconditionally. With the
default `USE_EXTERNAL_LLVM=ON` that reaches
`find_package(LLVM REQUIRED CONFIG)` at `dependencies/llvm.cmake:8`, so every
dependency build fails unless a system LLVM is installed. Setting
`USE_EXTERNAL_LLVM=OFF` avoids that only by building LLVM from source.

Neither is needed for `cobra-core`, which references zero LLVM symbols:

    $ nm -u build/lib/core/libcobra-core.a | grep -c -i llvm
    0

LLVM is used only by `lib/llvm`, which the main project already gates on
`COBRA_BUILD_LLVM_PASS` (`CMakeLists.txt:64`). The superbuild was missing the
same gate.

## Fix

Gate `include(llvm.cmake)` on `COBRA_BUILD_LLVM_PASS`, matching the main
project. Default is unchanged (OFF), so builds that do want the pass plugin
behave exactly as before by passing `-DCOBRA_BUILD_LLVM_PASS=ON`.

## Verification

Counterfactual, with LLVM hidden from CMake. Before the change:

    CMake Error at llvm.cmake:8 (find_package):
      Could NOT find LLVM (missing: LLVM_DIR)
    Call Stack (most recent call first):
      CMakeLists.txt:31 (include)

After the change the same command configures and builds cleanly:

    cmake -S dependencies -B build-deps -DCMAKE_BUILD_TYPE=Release
    cmake --build build-deps
    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
      -DCMAKE_PREFIX_PATH=$(pwd)/build-deps/install
    cmake --build build
    ./build/tools/cobra-cli/cobra-cli --mba "(x|y)-(x&y)" --bitwidth 32
    x ^ y

The dependency prefix contains no LLVM afterwards, and `cobra-cli` links only
CoreFoundation, libc++ and libSystem.

Verified on macOS arm64, macOS x86_64 and Linux (manylinux_2_28). Windows
additionally needs the companion MSVC fix, since `cobra-core` does not compile
under MSVC today.

## Motivation

This makes it possible to build `cobra-core` inside cibuildwheel images for
Python bindings, where installing a full LLVM is not practical.
