### PR TITLE
fix: make cobra-core build under MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ add_compile_options(
     $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers>
     $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-missing-designated-field-initializers>
     $<${_cobra_msvc}:/W4>
+    # C4146 "unary minus applied to unsigned type, result still unsigned" is
+    # exactly what the evaluators intend: (-x) & mask is two's-complement
+    # negation for Expr::Kind::kNeg, well-defined for unsigned types.  /sdl
+    # below promotes C4146 to an error, which breaks the MSVC build outright.
+    $<${_cobra_msvc}:/wd4146>
 )
 
 # Runtime hardening (GCC/Clang)

--- a/lib/core/StructureRecovery.cpp
+++ b/lib/core/StructureRecovery.cpp
@@ -6,6 +6,7 @@
 #include "cobra/core/SignatureChecker.h"
 #include "cobra/core/Trace.h"
 #include <algorithm>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <unordered_map>
@@ -165,9 +166,10 @@ namespace cobra {
                     // with fewer set bits — the resulting m*c is
                     // smaller, and when m*c == 0 the constant vanishes).
                     if (((a.coeff + b.coeff) & kMod) == 0) {
+                        // std::popcount, not __builtin_popcountll: the latter
+                        // is a GCC/Clang extension with no MSVC equivalent.
                         auto &src =
-                            (__builtin_popcountll(a.mask) <= __builtin_popcountll(b.mask)) ? a
-                                                                                           : b;
+                            (std::popcount(a.mask) <= std::popcount(b.mask)) ? a : b;
                         auto &dst = (&src == &a) ? b : a;
 
                         const uint64_t kM = src.coeff;


### PR DESCRIPTION
## Problem

`cobra-core` does not compile with MSVC. Two independent issues, both surfaced
by a build on windows-latest (VS 2022):

**1. `__builtin_popcountll` is a GCC/Clang extension.**
`lib/core/StructureRecovery.cpp:169` calls it directly:

    error C3861: '__builtin_popcountll': identifier not found

Four further errors cascade from it as the surrounding `auto &src` fails to
deduce (C2530, C3536, C2446 x2).

**2. `/sdl` promotes C4146 to an error.**
`CMakeLists.txt:41` enables `/sdl`, which turns this warning into a hard error:

    error C4146: unary minus operator applied to unsigned type, result still unsigned

It fires at five sites that deliberately compute two's-complement negation for
`Expr::Kind::kNeg`, all of the form `(-x) & mask`:

    lib/core/SignatureEval.cpp:71
    lib/core/TemplateDecomposer.cpp:184
    lib/core/TemplateDecomposer.cpp:1122
    lib/core/SemilinearSignature.cpp:46
    lib/core/SemilinearSignature.cpp:144

Negation of an unsigned value is well defined, and the masking makes the intent
explicit.

## Fix

1. Use `std::popcount` from `<bit>`. It is available since C++20 and the
   project already sets `CMAKE_CXX_STANDARD 23`, so no feature test is needed.
   The operand is `uint64_t`, making this a direct substitution.

2. Add `/wd4146` for MSVC. Suppressing reads better than rewriting the idiom at
   five sites: the negation is intentional, and the warning carries little
   signal in code that does modular arithmetic throughout. The comment in
   `CMakeLists.txt` records why.

## Verification

Builds clean on Windows (MSVC, VS 2022) where it previously failed.

Rebuilt on macOS arm64 to confirm no behaviour change:

    cmake --build build --target cobra-core
    ./build/tools/cobra-cli/cobra-cli --mba "(x|y)-(x&y)" --bitwidth 32
    x ^ y

Also green on macOS x86_64 and Linux (manylinux_2_28).

## Note

Independent of the change itself, building the dependency superbuild on a
machine without a system LLVM also requires the companion fix in #49 to
`dependencies/CMakeLists.txt`.
